### PR TITLE
Added setup.py for packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+import os
+
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'README')) as f:
+    README = f.read()
+
+requires = []
+
+setup(name='python-bitcoinlib',
+    version='1.0',
+    description='This python library provides an easy interface to the bitcoin data structures and protocol.',
+    long_description=README,
+    classifiers=[
+      "Programming Language :: Python",
+      ],
+    url='https://github.com/petertodd/python-bitcoinlib',
+    keywords='bitcoin',
+    packages=find_packages(),
+    zip_safe=False,
+    install_requires=requires,
+    )


### PR DESCRIPTION
Because python-bitcoinlib lacked a setup.py it had to be manually included in ngcccbase which was a less than ideal solution. Adding setup.py to python-bitcoinlib will allow users to specify it as a dependency more easily.
