### PR TITLE
Rework message serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 local*.cfg
 
+build/
+python_bitcoinlib.egg-info/

--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -23,8 +23,11 @@ MAX_MONEY = 21000000 * COIN
 MAX_BLOCK_SIZE = 1000000
 MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50
 
+BIP0031_VERSION = 60000
 PROTO_VERSION = 60002
 MIN_PROTO_VERSION = 209
+
+CADDR_TIME_VERSION = 31402
 
 def MoneyRange(nValue):
         return 0<= nValue <= MAX_MONEY
@@ -69,7 +72,7 @@ def b2lx(b):
 
 def str_money_value(value):
     """Convert an integer money value to a fixed point string"""
-    r = '%i.%08i' % (value // 100000000, value % 100000000)
+    r = '%i.%08i' % (value // COIN, value % COIN)
     r = r.rstrip('0')
     if r[-1] == '.':
         r += '0'
@@ -224,9 +227,9 @@ class CTransaction(Serializable):
 
 class CBlockHeader(Serializable):
     """A block header"""
-    __slots__ = ['nVersion', 'hashPrevBlock', 'hashMerkleRoot', 'nTime', 'nBits', 'nBits']
+    __slots__ = ['nVersion', 'hashPrevBlock', 'hashMerkleRoot', 'nTime', 'nBits', 'nNonce']
 
-    def __init__(self, nVersion=2, hashPrevBlock=None, hashMerkleRoot=None, nTime=None, nBits=None, nNonce=None):
+    def __init__(self, nVersion=2, hashPrevBlock=num_null_bytes(32), hashMerkleRoot=num_null_bytes(32), nTime=0, nBits=0, nNonce=0):
         self.nVersion = nVersion
         assert len(hashPrevBlock) == 32
         self.hashPrevBlock = hashPrevBlock
@@ -279,7 +282,7 @@ class CBlock(CBlockHeader):
     """A block including all transactions in it"""
     __slots__ = ['vtx']
 
-    def __init__(self, nVersion=2, hashPrevBlock=None, hashMerkleRoot=None, nTime=None, nBits=None, nNonce=None, vtx=None):
+    def __init__(self, nVersion=2, hashPrevBlock=num_null_bytes(32), hashMerkleRoot=num_null_bytes(32), nTime=0, nBits=0, nNonce=0, vtx=None):
         super(CBlock, self).__init__(nVersion, hashPrevBlock, hashMerkleRoot, nTime, nBits, nNonce)
         if not vtx:
             vtx = []

--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -18,25 +18,29 @@ import struct
 
 # Py3 compatibility
 import sys
-bchr = chr
-bord = ord
+
 if sys.version > '3':
     bchr = lambda x: bytes([x])
     bord = lambda x: x[0]
     from io import BytesIO
 else:
+    bchr = chr
+    bord = ord
     from cStringIO import StringIO as BytesIO
 
 MAX_SIZE = 0x02000000
 
+
 class SerializationError(Exception):
     """Base class for serialization errors"""
+
 
 class SerializationTruncationError(Exception):
     """Serialized data was truncated
 
     Thrown by deserialize() and stream_deserialize()
     """
+
 
 def ser_read(f, n):
     """Read from a stream safely
@@ -49,8 +53,16 @@ def ser_read(f, n):
         raise SerializationError('Asked to read 0x%x bytes; MAX_SIZE exceeded')
     r = f.read(n)
     if len(r) < n:
-        raise SerializationTruncationError()
+        raise SerializationTruncationError('Asked to read %i bytes, but only got %i' % (n, len(r)))
     return r
+
+
+def num_null_bytes(num):
+    res = b''
+    for i in range(num):
+        res += b'\x00'
+    return res
+
 
 class Serializable(object):
     """Base class for serializable objects"""
@@ -86,6 +98,7 @@ class Serializable(object):
     def __hash__(self):
         return hash(self.serialize())
 
+
 class Serializer(object):
     """Base class for object serializers"""
     def __new__(cls):
@@ -107,6 +120,7 @@ class Serializer(object):
     @classmethod
     def deserialize(cls, buf):
         return cls.stream_deserialize(BytesIO(buf))
+
 
 class VarIntSerializer(Serializer):
     """Serialization of variable length ints"""
@@ -138,6 +152,7 @@ class VarIntSerializer(Serializer):
         else:
             return struct.unpack(b'<Q', ser_read(f, 8))[0]
 
+
 class BytesSerializer(Serializer):
     """Serialization of bytes instances"""
     @classmethod
@@ -149,6 +164,7 @@ class BytesSerializer(Serializer):
     def stream_deserialize(cls, f):
         l = VarIntSerializer.stream_deserialize(f)
         return ser_read(f, l)
+
 
 class VectorSerializer(Serializer):
     """Base class for serializers of object vectors"""
@@ -166,22 +182,54 @@ class VectorSerializer(Serializer):
             r.append(inner_cls.stream_deserialize(f))
         return r
 
+
 class uint256VectorSerializer(Serializer):
     """Serialize vectors of uint256"""
     @classmethod
-    def stream_serialize(cls, inner_cls, objs, f):
-        VarIntSerializer.stream_serialize(len(objs), f)
-        for obj in objs:
-            assert len(obj) == 32
-            f.write(obj)
+    def stream_serialize(cls, uints, f):
+        VarIntSerializer.stream_serialize(len(uints), f)
+        for uint in uints:
+            assert len(uint) == 32
+            f.write(uint)
 
     @classmethod
-    def stream_deserialize(cls, inner_cls, f):
+    def stream_deserialize(cls, f):
         n = VarIntSerializer.stream_deserialize(f)
         r = []
         for i in range(n):
             r.append(ser_read(f, 32))
         return r
+
+
+class intVectorSerialzer(Serializer):
+    @classmethod
+    def stream_serialize(cls, ints, f):
+        l = len(ints)
+        VarIntSerializer.stream_serialize(l, f)
+        for i in ints:
+            f.write(struct.pack(b"<i", i))
+
+    @classmethod
+    def stream_deserialize(cls, f):
+        l = VarIntSerializer.stream_deserialize(f)
+        ints = []
+        for i in range(l):
+            ints.append(struct.unpack(b"<i", ser_read(f, 4)))
+
+
+class VarStringSerializer(Serializer):
+    """Serialize variable length strings"""
+    @classmethod
+    def stream_serialize(cls, s, f):
+        l = len(s)
+        VarIntSerializer.stream_serialize(l, f)
+        f.write(s)
+
+    @classmethod
+    def stream_deserialize(cls, f):
+        l = VarIntSerializer.stream_deserialize(f)
+        return ser_read(f, l)
+
 
 def uint256_from_str(s):
     """Convert bytes to uint256"""
@@ -190,6 +238,7 @@ def uint256_from_str(s):
     for i in range(8):
         r += t[i] << (i * 32)
     return r
+
 
 def uint256_from_compact(c):
     """Convert compact encoding to uint256
@@ -200,43 +249,16 @@ def uint256_from_compact(c):
     v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
     return v
 
+
 def uint256_to_shortstr(u):
     s = "%064x" % (u,)
     return s[:16]
 
-def deser_int_vector(f):
-    """Deserialize a vector of ints"""
-    nit = struct.unpack(b"<B", f.read(1))[0]
-    if nit == 253:
-        nit = struct.unpack(b"<H", f.read(2))[0]
-    elif nit == 254:
-        nit = struct.unpack(b"<I", f.read(4))[0]
-    elif nit == 255:
-        nit = struct.unpack(b"<Q", f.read(8))[0]
-    r = []
-    for i in range(nit):
-        t = struct.unpack(b"<i", f.read(4))[0]
-        r.append(t)
-    return r
-
-def ser_int_vector(l):
-    """Serialize a vector of ints"""
-    r = b""
-    if len(l) < 253:
-        r = bchr(len(l))
-    elif len(s) < 0x10000:
-        r = bchr(253) + struct.pack(b"<H", len(l))
-    elif len(s) < 0x100000000:
-        r = bchr(254) + struct.pack(b"<I", len(l))
-    else:
-        r = bchr(255) + struct.pack(b"<Q", len(l))
-    for i in l:
-        r += struct.pack(b"<i", i)
-    return r
 
 def Hash(msg):
     """SHA256^2)(msg) -> bytes"""
     return hashlib.sha256(hashlib.sha256(msg).digest()).digest()
+
 
 def Hash160(msg):
     """RIPEME160(SHA256(msg)) -> bytes"""

--- a/bitcoin/messages.py
+++ b/bitcoin/messages.py
@@ -12,206 +12,361 @@ import struct
 import time
 import random
 import sys
+from binascii import hexlify
 if sys.version > '3':
     import io
 else:
     import cStringIO as io
-from bitcoin.core import *
+
+from .core import *
+from .core.serialize import *
+from .net import *
+from bitcoin import MainParams
 
 MSG_TX = 1
 MSG_BLOCK = 2
 MSG_FILTERED_BLOCK = 3
 
-class msg_version(object):
-    command = b"version"
+
+class MsgSerializable(Serializable):
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = MIN_PROTO_VERSION
+        self.protover = protover
+
+    def msg_ser(self, f):
+        raise NotImplementedError
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        raise NotImplementedError
+
+    def to_bytes(self, params=MainParams()):
+        f = BytesIO()
+        self.msg_ser(f)
+        body = f.getvalue()
+        res = params.MESSAGE_START
+        res += self.command
+        res += b"\x00" * (12 - len(self.command))
+        res += struct.pack(b"<I", len(body))
+
+        # add checksum
+        th = hashlib.sha256(body).digest()
+        h = hashlib.sha256(th).digest()
+        res += h[:4]
+
+        res += body
+        return res
+
+    @classmethod
+    def from_bytes(cls, b, protover=PROTO_VERSION):
+        f = BytesIO(b)
+        return MsgSerializable.stream_deserialize(f, protover=protover)
+
+    @classmethod
+    def stream_deserialize(cls, f, params=MainParams(), protover=PROTO_VERSION):
+        recvbuf = ser_read(f, 4 + 12 + 4 + 4)
+
+        # check magic
+        if recvbuf[:4] != params.MESSAGE_START:
+            raise ValueError("Invalid message start '%s', expected '%s'" %
+                             (recvbuf[:4], params.MESSAGE_START))
+
+        # remaining header fields: command, msg length, checksum
+        command = recvbuf[4:4+12].split(b"\x00", 1)[0]
+        msglen = struct.unpack(b"<i", recvbuf[4+12:4+12+4])[0]
+        checksum = recvbuf[4+12+4:4+12+4+4]
+
+        # read message body
+        recvbuf += ser_read(f, msglen)
+
+        msg = recvbuf[4+12+4+4:4+12+4+4+msglen]
+        th = hashlib.sha256(msg).digest()
+        h = hashlib.sha256(th).digest()
+        if checksum != h[:4]:
+            raise ValueError("got bad checksum %s" % repr(recvbuf))
+            recvbuf = recvbuf[4+12+4+4+msglen:]
+
+        if command in messagemap:
+            cls = messagemap[command]
+            #        print("Going to deserialize '%s'" % msg)
+            return cls.msg_deser(BytesIO(msg))
+        else:
+            print("Command '%s' not in messagemap" % str(command, 'ascii'))
+            return None
+
+    def stream_serialize(self, f):
+        data = self.to_bytes()
+        f.write(data)
+
+
+class msg_version(MsgSerializable):
+    command = b"version"
+
+    def __init__(self, protover=PROTO_VERSION):
+        super(msg_version, self).__init__(protover)
         self.nVersion = protover
         self.nServices = 1
-        self.nTime = time.time()
-        self.addrTo = CAddress(MIN_PROTO_VERSION)
-        self.addrFrom = CAddress(MIN_PROTO_VERSION)
+        self.nTime = int(time.time())
+        self.addrTo = CAddress(PROTO_VERSION)
+        self.addrFrom = CAddress(PROTO_VERSION)
         self.nNonce = random.getrandbits(64)
         self.strSubVer = b'/python-bitcoin-0.0.1/'
         self.nStartingHeight = -1
-    def deserialize(self, f):
-        self.nVersion = struct.unpack(b"<i", f.read(4))[0]
-        if self.nVersion == 10300:
-            self.nVersion = 300
-        self.nServices = struct.unpack(b"<Q", f.read(8))[0]
-        self.nTime = struct.unpack(b"<q", f.read(8))[0]
-        self.addrTo = CAddress(MIN_PROTO_VERSION)
-        self.addrTo.deserialize(f)
-        if self.nVersion >= 106:
-            self.addrFrom = CAddress(MIN_PROTO_VERSION)
-            self.addrFrom.deserialize(f)
-            self.nNonce = struct.unpack(b"<Q", f.read(8))[0]
-            self.strSubVer = deser_string(f)
-            if self.nVersion >= 209:
-                self.nStartingHeight = struct.unpack(b"<i", f.read(4))[0]
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.nVersion = struct.unpack(b"<i", ser_read(f, 4))[0]
+        if c.nVersion == 10300:
+            c.nVersion = 300
+        c.nServices = struct.unpack(b"<Q", ser_read(f, 8))[0]
+        c.nTime = struct.unpack(b"<q", ser_read(f, 8))[0]
+        c.addrTo = CAddress.stream_deserialize(f, True)
+        if c.nVersion >= 106:
+            c.addrFrom = CAddress.stream_deserialize(f, True)
+            c.nNonce = struct.unpack(b"<Q", ser_read(f, 8))[0]
+            c.strSubVer = VarStringSerializer.stream_deserialize(f)
+            if c.nVersion >= 209:
+                c.nStartingHeight = struct.unpack(b"<i", ser_read(f,4))[0]
             else:
-                self.nStartingHeight = None
+                c.nStartingHeight = None
         else:
-            self.addrFrom = None
-            self.nNonce = None
-            self.strSubVer = None
-            self.nStartingHeight = None
-    def serialize(self):
-        r = b""
-        r += struct.pack(b"<i", self.nVersion)
-        r += struct.pack(b"<Q", self.nServices)
-        r += struct.pack(b"<q", self.nTime)
-        r += self.addrTo.serialize()
-        r += self.addrFrom.serialize()
-        r += struct.pack(b"<Q", self.nNonce)
-        r += ser_string(self.strSubVer)
-        r += struct.pack(b"<i", self.nStartingHeight)
-        return r
+            c.addrFrom = None
+            c.nNonce = None
+            c.strSubVer = None
+            c.nStartingHeight = None
+        return c
+ 
+    def msg_ser(self, f):
+        f.write(struct.pack(b"<i", self.nVersion))
+        f.write(struct.pack(b"<Q", self.nServices))
+        f.write(struct.pack(b"<q", self.nTime))
+        self.addrTo.stream_serialize(f, True)
+        self.addrFrom.stream_serialize(f, True)
+        f.write(struct.pack(b"<Q", self.nNonce))
+        VarStringSerializer.stream_serialize(self.strSubVer, f)
+        f.write(struct.pack(b"<i", self.nStartingHeight))
+
     def __repr__(self):
         return "msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%s addrFrom=%s nNonce=0x%016X strSubVer=%s nStartingHeight=%i)" % (self.nVersion, self.nServices, time.ctime(self.nTime), repr(self.addrTo), repr(self.addrFrom), self.nNonce, self.strSubVer, self.nStartingHeight)
 
-class msg_verack(object):
+
+class msg_verack(MsgSerializable):
     command = b"verack"
+
     def __init__(self, protover=PROTO_VERSION):
+        super(msg_verack, self).__init__(protover)
         self.protover = protover
-    def deserialize(self, f):
-        pass
-    def serialize(self):
-        return b""
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        return cls()
+
+    def msg_ser(self, f):
+        f.write(b"")
+
     def __repr__(self):
         return "msg_verack()"
 
-class msg_addr(object):
+
+class msg_addr(MsgSerializable):
     command = b"addr"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
+        super(msg_addr, self).__init__(protover)
         self.addrs = []
-    def deserialize(self, f):
-        self.addrs = deser_vector(f, CAddress, self.protover)
-    def serialize(self):
-        return ser_vector(self.addrs)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.addrs = VectorSerializer.stream_deserialize(CAddress, f)
+        return c
+
+    def msg_ser(self, f):
+        VectorSerializer.stream_serialize(CAddress, self.addrs, f)
+
     def __repr__(self):
         return "msg_addr(addrs=%s)" % (repr(self.addrs))
 
-class msg_alert(object):
+
+class msg_alert(MsgSerializable):
     command = b"alert"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
+        super(msg_alert, self).__init__(protover)
         self.alert = CAlert()
-    def deserialize(self, f):
-        self.alert = CAlert()
-        self.alert.deserialize(f)
-    def serialize(self):
-        r = b""
-        r += self.alert.serialize()
-        return r
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.alert = CAlert.stream_deserialize(f)
+        return c
+
+    def msg_ser(self, f):
+        self.alert.stream_serialize(f)
+
     def __repr__(self):
         return "msg_alert(alert=%s)" % (repr(self.alert), )
 
-class msg_inv(object):
+
+class msg_inv(MsgSerializable):
     command = b"inv"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
+        super(msg_inv, self).__init__(protover)
         self.inv = []
-    def deserialize(self, f):
-        self.inv = deser_vector(f, CInv)
-    def serialize(self):
-        return ser_vector(self.inv)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.inv = VectorSerializer.stream_deserialize(CInv, f)
+        return c
+
+    def msg_ser(self, f):
+        VectorSerializer.stream_serialize(CInv, self.inv, f)
+
     def __repr__(self):
         return "msg_inv(inv=%s)" % (repr(self.inv))
 
-class msg_getdata(object):
+
+class msg_getdata(MsgSerializable):
     command = b"getdata"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
+        super(msg_getdata, self).__init__(protover)
         self.inv = []
-    def deserialize(self, f):
-        self.inv = deser_vector(f, CInv)
-    def serialize(self):
-        return ser_vector(self.inv)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.inv = VectorSerializer.stream_deserialize(CInv, f)
+        return c
+
+    def msg_ser(self, f):
+        VectorSerializer.stream_serialize(CInv, self.inv, f)
+
     def __repr__(self):
         return "msg_getdata(inv=%s)" % (repr(self.inv))
 
-class msg_getblocks(object):
+
+class msg_getblocks(MsgSerializable):
     command = b"getblocks"
-    def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
-        self.locator = CBlockLocator()
-        self.hashstop = 0
-    def deserialize(self, f):
-        self.locator = CBlockLocator()
-        self.locator.deserialize(f)
-        self.hashstop = f.read(32)
-    def serialize(self):
-        r = b""
-        r += self.locator.serialize()
-        r += self.hashstop
-        return r
-    def __repr__(self):
-        return "msg_getblocks(locator=%s hashstop=%064x)" % (repr(self.locator), self.hashstop)
 
-class msg_getheaders(object):
+    def __init__(self, protover=PROTO_VERSION):
+        super(msg_getblocks, self).__init__(protover)
+        self.locator = CBlockLocator()
+        self.hashstop = num_null_bytes(32)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.locator = CBlockLocator.stream_deserialize(f)
+        c.hashstop = ser_read(f, 32)
+        return c
+
+    def msg_ser(self, f):
+        self.locator.stream_serialize(f)
+        f.write(self.hashstop)
+
+    def __repr__(self):
+        return "msg_getblocks(locator=%s hashstop=%s)" % (repr(self.locator), hexlify(self.hashstop))
+
+
+class msg_getheaders(MsgSerializable):
     command = b"getheaders"
-    def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
-        self.locator = CBlockLocator()
-        self.hashstop = 0
-    def deserialize(self, f):
-        self.locator = CBlockLocator()
-        self.locator.deserialize(f)
-        self.hashstop = f.read(32)
-    def serialize(self):
-        r = b""
-        r += self.locator.serialize()
-        r += self.hashstop
-        return r
-    def __repr__(self):
-        return "msg_getheaders(locator=%s hashstop=%064x)" % (repr(self.locator), self.hashstop)
 
-class msg_headers(object):
-    command = b"headers"
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
+        super(msg_getheaders, self).__init__(protover)
+        self.locator = CBlockLocator()
+        self.hashstop = num_null_bytes(32)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.locator = CBlockLocator.stream_deserialize(f)
+        c.hashstop = ser_read(f, 32)
+        return c
+
+    def msg_ser(self, f):
+        self.locator.stream_serialize(f)
+        f.write(self.hashstop)
+
+    def __repr__(self):
+        return "msg_getheaders(locator=%s hashstop=%s)" % (repr(self.locator), hexlify(self.hashstop))
+
+
+class msg_headers(MsgSerializable):
+    command = b"headers"
+
+    def __init__(self, protover=PROTO_VERSION):
+        super(msg_headers, self).__init__(protover)
         self.headers = []
-    def deserialize(self, f):
-        self.headers = deser_vector(f, CBlock)
-    def serialize(self):
-        return ser_vector(self.headers)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.headers = VectorSerializer.stream_deserialize(CBlock, f)
+        return c
+
+    def msg_ser(self, f):
+        VectorSerializer.stream_serialize(CBlock, self.headers, f)
+
     def __repr__(self):
         return "msg_headers(headers=%s)" % (repr(self.headers))
 
-class msg_tx(object):
+
+class msg_tx(MsgSerializable):
     command = b"tx"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
+        super(msg_tx, self).__init__(protover)
         self.tx = CTransaction()
-    def deserialize(self, f):
-        self.tx.deserialize(f)
-    def serialize(self):
-        return self.tx.serialize()
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.tx = CTransaction.stream_deserialize(f)
+        return c
+
+    def msg_ser(self, f):
+        self.tx.stream_serialize(f)
+
     def __repr__(self):
         return "msg_tx(tx=%s)" % (repr(self.tx))
 
-class msg_block(object):
+
+class msg_block(MsgSerializable):
     command = b"block"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
+        super(msg_block, self).__init__(protover)
         self.block = CBlock()
-    def deserialize(self, f):
-        self.block.deserialize(f)
-    def serialize(self):
-        return self.block.serialize()
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.block = CBlock.stream_deserialize(f)
+        return c
+
+    def msg_ser(self, f):
+        self.block.stream_serialize(f)
+
     def __repr__(self):
         return "msg_block(block=%s)" % (repr(self.block))
 
-class msg_getaddr(object):
+
+class msg_getaddr(MsgSerializable):
     command = b"getaddr"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
-    def deserialize(self, f):
+        super(msg_getaddr, self).__init__(protover)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        return cls()
+
+    def msg_ser(self, f):
         pass
-    def serialize(self):
-        return b""
+
     def __repr__(self):
         return "msg_getaddr()"
 
@@ -219,119 +374,68 @@ class msg_getaddr(object):
 #msg_submitorder
 #msg_reply
 
-class msg_ping(object):
+
+class msg_ping(MsgSerializable):
     command = b"ping"
+
     def __init__(self, protover=PROTO_VERSION, nonce=0):
-        self.protover = protover
+        super(msg_ping, self).__init__(protover)
         self.nonce = nonce
-    def deserialize(self, f):
-        if self.protover > BIP0031_VERSION:
-            self.nonce = struct.unpack(b"<Q", f.read(8))[0]
-    def serialize(self):
-        r = b""
-        if self.protover > BIP0031_VERSION:
-            r += struct.pack(b"<Q", self.nonce)
-        return r
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.nonce = struct.unpack(b"<Q", ser_read(f, 8))[0]
+        return c
+
+    def msg_ser(self, f):
+        f.write(struct.pack(b"<Q", self.nonce))
+
     def __repr__(self):
         return "msg_ping(0x%x)" % (self.nonce,)
 
-class msg_pong(object):
+
+class msg_pong(MsgSerializable):
     command = b"pong"
+
     def __init__(self, protover=PROTO_VERSION, nonce=0):
-        self.protover = protover
+        super(msg_pong, self).__init__(protover)
         self.nonce = nonce
-    def deserialize(self, f):
-        self.nonce = struct.unpack(b"<Q", f.read(8))[0]
-    def serialize(self):
-        r = b""
-        r += struct.pack(b"<Q", self.nonce)
-        return r
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        c = cls()
+        c.nonce = struct.unpack(b"<Q", ser_read(f,8))[0]
+        return c
+
+    def msg_ser(self, f):
+        f.write(struct.pack(b"<Q", self.nonce))
+
     def __repr__(self):
         return "msg_pong(0x%x)" % (self.nonce,)
 
-class msg_mempool(object):
+
+class msg_mempool(MsgSerializable):
     command = b"mempool"
+
     def __init__(self, protover=PROTO_VERSION):
-        self.protover = protover
-    def deserialize(self, f):
+        super(msg_mempool, self).__init__(protover)
+
+    @classmethod
+    def msg_deser(cls, f, protover=PROTO_VERSION):
+        return cls()
+
+    def msg_ser(self, f):
         pass
-    def serialize(self):
-        return b""
+
     def __repr__(self):
         return "msg_mempool()"
 
-messagemap = {
-    "version": msg_version,
-    "verack": msg_verack,
-    "addr": msg_addr,
-    "alert": msg_alert,
-    "inv": msg_inv,
-    "getdata": msg_getdata,
-    "getblocks": msg_getblocks,
-    "tx": msg_tx,
-    "block": msg_block,
-    "getaddr": msg_getaddr,
-    "ping": msg_ping,
-    "pong": msg_pong,
-    "mempool": msg_mempool
-}
+msg_classes = [msg_version, msg_verack, msg_addr, msg_alert, msg_inv,
+               msg_getdata, msg_getblocks, msg_getheaders,
+               msg_headers, msg_tx, msg_block, msg_getaddr, msg_ping,
+               msg_pong, msg_mempool]
 
-def message_read(netmagic, f):
-    try:
-        recvbuf = f.read(4 + 12 + 4 + 4)
-    except IOError:
-        return None
-    
-    # check magic
-    if len(recvbuf) < 4:
-        return
-    if recvbuf[:4] != netmagic.msg_start:
-        raise ValueError("got garbage %s" % repr(recvbuf))
-
-    # check checksum
-    if len(recvbuf) < 4 + 12 + 4 + 4:
-        return
-
-    # remaining header fields: command, msg length, checksum
-    command = recvbuf[4:4+12].split(b"\x00", 1)[0]
-    msglen = struct.unpack(b"<i", recvbuf[4+12:4+12+4])[0]
-    checksum = recvbuf[4+12+4:4+12+4+4]
-
-    # read message body
-    try:
-        recvbuf += f.read(msglen)
-    except IOError:
-        return None
-
-    msg = recvbuf[4+12+4+4:4+12+4+4+msglen]
-    th = hashlib.sha256(msg).digest()
-    h = hashlib.sha256(th).digest()
-    if checksum != h[:4]:
-        raise ValueError("got bad checksum %s" % repr(recvbuf))
-    recvbuf = recvbuf[4+12+4+4+msglen:]
-
-    if command in messagemap:
-        f = io.StringIO(msg)
-        t = messagemap[command]()
-        t.deserialize(f)
-        return t
-    else:
-        return None
-
-def message_to_str(netmagic, message):
-    command = message.command
-    data = message.serialize()
-    tmsg = netmagic.msg_start
-    tmsg += command
-    tmsg += b"\x00" * (12 - len(command))
-    tmsg += struct.pack(b"<I", len(data))
-
-    # add checksum
-    th = hashlib.sha256(data).digest()
-    h = hashlib.sha256(th).digest()
-    tmsg += h[:4]
-
-    tmsg += data
-
-    return tmsg
-
+messagemap = {}
+for cls in msg_classes:
+    messagemap[cls.command] = cls

--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -450,3 +450,16 @@ class Proxy(RawProxy):
         if 'pubkey' in r:
             r['pubkey'] = unhexlify(r['pubkey'])
         return r
+
+    def _addnode(self, node, arg):
+        r = self._call('addnode', node, arg)
+        return r
+
+    def addnode(self, node):
+        return self._addnode(node, 'add')
+
+    def addnodeonetry(self, node):
+        return self._addnode(node, 'onetry')
+
+    def removenode(self, node):
+        return self._addnode(node, 'remove')

--- a/bitcoin/tests/test_messages.py
+++ b/bitcoin/tests/test_messages.py
@@ -1,0 +1,112 @@
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+
+from bitcoin.messages import msg_version, msg_verack, msg_addr, msg_alert, \
+    msg_inv, msg_getdata, msg_getblocks, msg_getheaders, msg_headers, msg_tx, \
+    msg_block, msg_getaddr, msg_ping, msg_pong, msg_mempool, MsgSerializable
+
+import sys
+if sys.version > '3':
+    from io import BytesIO
+else:
+    from cStringIO import StringIO as BytesIO
+
+
+class MessageTestCase(unittest.TestCase):
+    def serialization_test(self, cls):
+        m = cls()
+        mSerialized = m.to_bytes()
+        mDeserialzed = cls.from_bytes(mSerialized)
+        mSerialzedTwice = mDeserialzed.to_bytes()
+        self.assertEqual(mSerialized, mSerialzedTwice)
+
+
+class Test_msg_version(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_version)
+
+
+class Test_msg_verack(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_verack)
+
+
+class Test_msg_addr(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_addr)
+
+
+class Test_msg_alert(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_alert)
+
+
+class Test_msg_inv(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_inv)
+
+
+class Test_msg_getdata(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_getdata)
+
+
+class Test_msg_getblocks(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_getblocks)
+
+
+class Test_msg_getheaders(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_getheaders)
+
+
+class Test_msg_headers(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_headers)
+
+
+class Test_msg_tx(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_tx)
+
+
+class Test_msg_block(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_block)
+
+
+class Test_msg_getaddr(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_getaddr)
+
+
+class Test_msg_ping(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_ping)
+
+
+class Test_msg_pong(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_pong)
+
+
+class Test_msg_mempool(MessageTestCase):
+    def test_serialization(self):
+        super().serialization_test(msg_mempool)
+
+
+class Test_messages(unittest.TestCase):
+    verackbytes = b'\xf9\xbe\xb4\xd9verack\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00]\xf6\xe0\xe2'
+
+    def test_read_msg_verack(self):
+        f = BytesIO(__class__.verackbytes)
+        m = MsgSerializable.stream_deserialize(f)
+        self.assertEqual(m.command, msg_verack.command)
+
+    def test_msg_verack_to_bytes(self):
+        m = msg_verack()
+        b = m.to_bytes()
+        self.assertEqual(__class__.verackbytes, b)

--- a/bitcoin/tests/test_net.py
+++ b/bitcoin/tests/test_net.py
@@ -1,0 +1,14 @@
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+
+from bitcoin.net import CAddress
+
+class Test_CAddress(unittest.TestCase):
+    def test_serialization(self):
+        c = CAddress()
+        cSerialized = c.serialize()
+        cDeserialized = CAddress.deserialize(cSerialized)
+        cSerializedTwice = cDeserialized.serialize()
+        self.assertEqual(cSerialized, cSerializedTwice)

--- a/examples/msg-serializable.py
+++ b/examples/msg-serializable.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+#
+# serialize.py
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+"""Serialize some bitcoin datastructures and show them in serialized and repr form."""
+
+from bitcoin import SelectParams
+from bitcoin.messages import msg_version, msg_tx, msg_block
+
+SelectParams('mainnet')
+
+
+for c in [msg_version, msg_tx, msg_block]:
+    # Instanciate the message with some default values
+    msg = c()
+    name = c.__name__
+    print(name + " repr:")
+    print(msg)
+    print(name + " serialized:")
+    print(msg.to_bytes())

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,5 @@ setup(name='python-bitcoinlib',
     packages=find_packages(),
     zip_safe=False,
     install_requires=requires,
+    test_suite="bitcoin.tests"
     )


### PR DESCRIPTION
Hi peter, would be glad to hear your input on those changes. :)

Please note that the unit tests fail with python2 and, while I tried my best to keep python2 compatible, I can't really comment what works with python2 and what not, since I'm using python3 exclusively.

Classes that can be (de-)serialized are now sub-classes of 'Serializable'. Since message classes need an extra treatment when it comes to serialization, there is an additional MsgSerializable between them and Serializable.
