### PR TITLE
Use multi-line import statements

### DIFF
--- a/bitcoin/__init__.py
+++ b/bitcoin/__init__.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import bitcoin.core
 

--- a/bitcoin/base58.py
+++ b/bitcoin/base58.py
@@ -12,7 +12,12 @@
 
 """Base58 encoding and decoding"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import sys
 bchr = chr

--- a/bitcoin/bloom.py
+++ b/bitcoin/bloom.py
@@ -11,7 +11,12 @@
 
 """Bloom filter support"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import struct
 import sys

--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import binascii
 import hashlib

--- a/bitcoin/core/bignum.py
+++ b/bitcoin/core/bignum.py
@@ -11,7 +11,12 @@
 
 """Bignum routines"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import struct
 

--- a/bitcoin/core/script.py
+++ b/bitcoin/core/script.py
@@ -15,7 +15,12 @@ Functionality to build scripts, as well as SignatureHash(). Script evaluation
 is in bitcoin.core.scripteval
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import sys
 bchr = chr

--- a/bitcoin/core/scripteval.py
+++ b/bitcoin/core/scripteval.py
@@ -16,7 +16,12 @@ unlikely to match Satoshi Bitcoin exactly. Think carefully before using this
 module.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import sys
 bord = ord

--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -14,7 +14,12 @@
 You probabably don't need to use these directly.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import hashlib
 import struct

--- a/bitcoin/messages.py
+++ b/bitcoin/messages.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import struct
 import time

--- a/bitcoin/net.py
+++ b/bitcoin/net.py
@@ -9,13 +9,22 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import struct
 import socket
 from binascii import hexlify
 
-from .core import PROTO_VERSION, CADDR_TIME_VERSION
+from .core import (
+    PROTO_VERSION,
+    CADDR_TIME_VERSION,
+)
+
 from .core.serialize import *
 
 

--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -12,7 +12,12 @@
 
 """Bitcoin Core RPC support"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 try:
     import http.client as httplib
@@ -31,7 +36,17 @@ except ImportError:
     import urlparse
 
 import bitcoin
-from bitcoin.core import COIN, lx, b2lx, CBlock, CTransaction, COutPoint, CTxOut
+
+from bitcoin.core import (
+    COIN,
+    lx,
+    b2lx,
+    CBlock,
+    CTransaction,
+    COutPoint,
+    CTxOut,
+)
+
 from bitcoin.core.script import CScript
 from bitcoin.wallet import CBitcoinAddress
 

--- a/bitcoin/tests/__init__.py
+++ b/bitcoin/tests/__init__.py
@@ -9,4 +9,9 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)

--- a/bitcoin/tests/test_base58.py
+++ b/bitcoin/tests/test_base58.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import json
 import os

--- a/bitcoin/tests/test_bloom.py
+++ b/bitcoin/tests/test_bloom.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import json
 import os

--- a/bitcoin/tests/test_checkblock.py
+++ b/bitcoin/tests/test_checkblock.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import json
 import unittest

--- a/bitcoin/tests/test_core.py
+++ b/bitcoin/tests/test_core.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import unittest
 

--- a/bitcoin/tests/test_key.py
+++ b/bitcoin/tests/test_key.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import unittest
 

--- a/bitcoin/tests/test_messages.py
+++ b/bitcoin/tests/test_messages.py
@@ -11,9 +11,24 @@
 
 import unittest
 
-from bitcoin.messages import msg_version, msg_verack, msg_addr, msg_alert, \
-    msg_inv, msg_getdata, msg_getblocks, msg_getheaders, msg_headers, msg_tx, \
-    msg_block, msg_getaddr, msg_ping, msg_pong, msg_mempool, MsgSerializable
+from bitcoin.messages import (
+    msg_version,
+    msg_verack,
+    msg_addr,
+    msg_alert,
+    msg_inv,
+    msg_getdata,
+    msg_getblocks,
+    msg_getheaders,
+    msg_headers,
+    msg_tx,
+    msg_block,
+    msg_getaddr,
+    msg_ping,
+    msg_pong,
+    msg_mempool,
+    MsgSerializable,
+)
 
 import sys
 if sys.version > '3':

--- a/bitcoin/tests/test_rpc.py
+++ b/bitcoin/tests/test_rpc.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import unittest
 

--- a/bitcoin/tests/test_script.py
+++ b/bitcoin/tests/test_script.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import unittest
 import os

--- a/bitcoin/tests/test_scripteval.py
+++ b/bitcoin/tests/test_scripteval.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import json
 import os

--- a/bitcoin/tests/test_serialize.py
+++ b/bitcoin/tests/test_serialize.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import unittest
 import os

--- a/bitcoin/tests/test_transactions.py
+++ b/bitcoin/tests/test_transactions.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import json
 import unittest

--- a/bitcoin/tests/test_wallet.py
+++ b/bitcoin/tests/test_wallet.py
@@ -9,7 +9,12 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE file.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import unittest
 

--- a/bitcoin/wallet.py
+++ b/bitcoin/wallet.py
@@ -15,7 +15,12 @@ Includes things like representing addresses and converting them to/from
 scriptPubKeys; currently there is no actual wallet support implemented.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import sys
 bchr = chr


### PR DESCRIPTION
This switches the syntax used for long import lists into a format that
uses multiple lines. One particular benefit of this format is that diffs
more clearly show when certain imported symbols were added or removed.

The original format looks like:

```
from submodule import x, y, z
```

And this new format looks like:

```
from submodule import (
    x,
    y,

    # comments!
    z,
)
```
