### PR TITLE
Add a test for proper exception raising on bad start

### DIFF
--- a/bitcoin/tests/test_messages.py
+++ b/bitcoin/tests/test_messages.py
@@ -114,6 +114,12 @@ class Test_messages(unittest.TestCase):
         m = MsgSerializable.stream_deserialize(f)
         self.assertEqual(m.command, msg_verack.command)
 
+    def test_fail_invalid_message(self):
+        bad_verack_bytes = b'\xf8' + self.verackbytes[1:]
+        f = BytesIO(bad_verack_bytes)
+        with self.assertRaises(ValueError):
+            MsgSerializable.stream_deserialize(f)
+
     def test_msg_verack_to_bytes(self):
         m = msg_verack()
         b = m.to_bytes()


### PR DESCRIPTION
A test to confirm the fix on https://github.com/icook/python-bitcoinlib/commit/bdfc18a2b564853b007f3b36585d2c668a769ba2#commitcomment-8588990. It appears the actual issue is passing a string instead of bytes object in Python 2.7. I read several docs that stated "bytes in Python 2.7 is simply an alias for str" but in this case it appears to not behave quite the same. In the test I wrote on Python 2.7 if I remove the "b" before my string it raises a formatting exception. With the b it works fine. This is likely a systemic issue, and I'm not sure of a clever way to catch it and provide helpful exceptions to users... It seems silly/wasteful/painful to try and wrap all format bytes calls with b2x.
