### PR TITLE
Added SSL functionality

### DIFF
--- a/examples/bip-0070-payment-protocol.py
+++ b/examples/bip-0070-payment-protocol.py
@@ -12,7 +12,7 @@
 # LICENSE file.
 
 """Bip-0070-related functionality
-Creates http response objects suitable for use with
+Creates http(s) response objects suitable for use with
 bitcoin bip 70 using googles protocol buffers.
 """
 

--- a/examples/bip-0070-payment-protocol.py
+++ b/examples/bip-0070-payment-protocol.py
@@ -64,7 +64,6 @@ def paymentrequest():
 #####################################################################################################
 
 ##  Certificate chain example using nginx and ssl certificates obtained from comodo.com.
-##  This step is optional.
     #ssl_dir = '/etc/nginx/ssl/'
     #cert0 = open(ssl_dir + 'example_com.der', 'rb').read()
     #cert1 = open(ssl_dir + 'COMODORSADomainValidationSecureServerCA.der', 'rb').read()

--- a/examples/bip-0070-payment-protocol.py
+++ b/examples/bip-0070-payment-protocol.py
@@ -21,6 +21,7 @@ import urllib2
 ##  The payments_pb2 template is available at
 ##  https://github.com/bitcoin/bips/blob/master/bip-0070/paymentrequest.proto
 import payments_pb2
+##  Instantiate main protobuf object (o).
 o = payments_pb2
 
 import bitcoin
@@ -40,9 +41,6 @@ from Crypto.PublicKey import RSA
 
 def paymentrequest():
     """Generates a http(s) PaymentRequest object"""
-
-##  Instantiate main protobuf object (o).
-    o = payments_pb2
 
 ##  Setting the 'amount' field to 0 (zero) should prompt the user to enter
 ##  the amount for us but a bug in bitcoin core qt version 0.9.1 (at time of

--- a/examples/bip-0070-payment-protocol.py
+++ b/examples/bip-0070-payment-protocol.py
@@ -18,12 +18,6 @@ bitcoin bip 70 using googles protocol buffers.
 
 import urllib2
 
-##  The payments_pb2 template is available at
-##  https://github.com/bitcoin/bips/blob/master/bip-0070/paymentrequest.proto
-import payments_pb2
-##  Instantiate main protobuf object (o).
-o = payments_pb2
-
 import bitcoin
 #bitcoin.SelectParams('testnet')
 from bitcoin.wallet import CBitcoinAddress
@@ -38,6 +32,12 @@ from time import time
 from Crypto.Hash import SHA256
 from Crypto.Signature import PKCS1_v1_5
 from Crypto.PublicKey import RSA
+
+##  The payments_pb2 template is available at
+##  https://github.com/bitcoin/bips/blob/master/bip-0070/paymentrequest.proto
+import payments_pb2
+##  Instantiate main protobuf object (o).
+o = payments_pb2
 
 def paymentrequest():
     """Generates a http(s) PaymentRequest object"""

--- a/examples/bip-0070-payment-protocol.py
+++ b/examples/bip-0070-payment-protocol.py
@@ -1,20 +1,25 @@
 #!/usr/bin/python2.7
+
+# Copyright (C) 2013-2014 The python-bitcoinlib developers
 #
-# bip-0070-payment-protocol.py
+# This file is part of python-bitcoinlib.
 #
-# Distributed under the MIT/X11 software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
 #
+# No part of python-bitcoinlib, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
 
 """Bip-0070-related functionality
-
 Creates http response objects suitable for use with
 bitcoin bip 70 using googles protocol buffers.
 """
 
 import urllib2
 
-# https://github.com/bitcoin/bips/blob/master/bip-0070/paymentrequest.proto
+##  The payments_pb2 template is available at
+##  https://github.com/bitcoin/bips/blob/master/bip-0070/paymentrequest.proto
 import payments_pb2
 o = payments_pb2
 
@@ -26,50 +31,95 @@ from bitcoin.rpc import Proxy
 
 from time import time
 
-def payment_request():
-    """Generates a http PaymentRequest object"""
+##  To access the following librarys you will need to install pycrypto.
+##  This can be done using pip 'sudo pip install pycrypto'
+##  pycrypto hashing library imports
+from Crypto.Hash import SHA256
+from Crypto.Signature import PKCS1_v1_5
+from Crypto.PublicKey import RSA
 
-    bc = Proxy()
-    btc = bc.getnewaddress()
+def paymentrequest():
+    """Generates a http(s) PaymentRequest object"""
 
-#   Setting the 'amount' field to 0 (zero) should prompt the user to enter
-#   the amount for us but a bug in bitcoin core qt version 0.9.1 (at time of
-#   writing) wrongly informs us that the value is too small and aborts.
-#   https://github.com/bitcoin/bitcoin/issues/3095
-#   Also there can be no leading 0's (zeros).
-    btc_amount = 100000
-    serialized_pubkey = btc.to_scriptPubKey()
+##  Instantiate main protobuf object (o).
+    o = payments_pb2
 
+##  Setting the 'amount' field to 0 (zero) should prompt the user to enter
+##  the amount for us but a bug in bitcoin core qt version 0.9.1 (at time of
+##  writing) wrongly informs us that the value is too small and aborts.
+##  https://github.com/bitcoin/bitcoin/issues/3095
+##  Also there can be no leading 0's (zeros).
+    btc_amount = 100000000 # 1 BTC
+    serialized_pubkey = btc_address.to_scriptPubKey()
+
+##  Instantiate PaymentDetails object (pdo).
     pdo = o.PaymentDetails()
     #pdo.network = 'test'
-    pdo.outputs.add(amount = btc_amount,script = serialized_pubkey)
+    pdo.outputs.add(amount = btc_amount, script = serialized_pubkey)
     pdo.time = int(time())
     pdo.memo = 'String shown to user before confirming payment'
     pdo.payment_url = 'http://payment_ack.url'
 
+#####################################################################################################
+##  If you want to enable ssl verification in your payment requests you will need to uncomment all ##
+##  of the following CODE below.  If you're not interested in ssl then ignore the commented parts. ##
+#####################################################################################################
+
+##  Certificate chain example using nginx and ssl certificates obtained from comodo.com.
+##  This step is optional.
+    #ssl_dir = '/etc/nginx/ssl/'
+    #cert0 = open(ssl_dir + 'example_com.der', 'rb').read()
+    #cert1 = open(ssl_dir + 'COMODORSADomainValidationSecureServerCA.der', 'rb').read()
+    #cert2 = open(ssl_dir + 'COMODORSAAddTrustCA.der', 'rb').read()
+    #cert3 = open(ssl_dir + 'AddTrustExternalCARoot.der', 'rb').read()
+
+##  According to the documentation if you wish to use ssl the certificates are to be added one by one
+##  using the 'append()' method in the correct order.
+##  We can achieve this with a list and for loop.
+    #cert_list = (cert0, cert1, cert2, cert3)
+
+##  Instantiate X509Certificates object (xco)
+    #xco = o.X509Certificates()
+    #for i in cert_list:
+    #    xco.certificate.append(i)
+
+
+##  Instantiate PaymentRequest object (pro)
     pro = o.PaymentRequest()
+    #pro.pki_type = 'x509+sha256'
+    #pro.pki_data = xco.SerializeToString()
     pro.serialized_payment_details = pdo.SerializeToString()
-    
+
+    #keyDER = open(ssl_dir + 'example.der', 'rb').read()
+
+##  Documentation insists that the signature field should be manually set to empty before proceeding.
+    #pro.signature = ""
+    #pro_hash = SHA256.new(pro.SerializeToString())
+    #private_key = RSA.importKey(keyDER)
+    #signer = PKCS1_v1_5.new(private_key)
+    #pro.signature = signer.sign(pro_hash)
+
     sds_pr = pro.SerializeToString()
-    
+
     open('sds_pr_blob', 'wb').write(sds_pr)
-    headers = {'Content-Type' : 'application/bitcoin-payment', 'Accept' : 'application/bitcoin-paymentrequest'}
+    headers = {'Content-Type': 'application/bitcoin-payment',
+               'Accept': 'application/bitcoin-paymentrequest'}
     http_response_object = urllib2.Request('file:sds_pr_blob', None, headers)
 
     return http_response_object
 
-
 def payment_ack(serialized_Payment_message):
     """Generates a PaymentACK object, captures client refund address and returns a message"""
 
+##  Instantiate PaymentACK object (pao)
     pao = o.PaymentACK()
     pao.payment.ParseFromString(serialized_Payment_message)
     pao.memo = 'String shown to user after payment confirmation'
 
     refund_address = CBitcoinAddress.from_scriptPubKey(CScript(pao.payment.refund_to[0].script))
-    
+
     sds_pa = pao.SerializeToString()
-    
+
     open('sds_pa_blob', 'wb').write(sds_pa)
     headers = {'Content-Type' : 'application/bitcoin-payment', 'Accept' : 'application/bitcoin-paymentack'}
     http_response_object = urllib2.Request('file:sds_pa_blob', None, headers)

--- a/examples/bip-0070-payment-protocol.py
+++ b/examples/bip-0070-payment-protocol.py
@@ -72,7 +72,6 @@ def paymentrequest():
 
 ##  According to the documentation if you wish to use ssl the certificates are to be added one by one
 ##  using the 'append()' method in the correct order.
-##  We can achieve this with a list and for loop.
     #cert_list = (cert0, cert1, cert2, cert3)
 
 ##  Instantiate X509Certificates object (xco)


### PR DESCRIPTION
Included place holders for SSL certificate chains.
It is worth noting that the 'paymentrequest' function is currently dependant on the 'pycrypto' library which can be installed using pip but it would be more elegant to use 'hashlib' if possible.
Also the 'sds_pr' and 'sds_pa' variables are written to the physical disk which is undesirable. It would make more sense to use 'BytesIO' or 'StringIO' from the 'io' library (which ever is appropriate).