### PR TITLE
Implemented getreceivedbyaddress RPC call

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -322,6 +322,21 @@ class Proxy(RawProxy):
 
         return r
 
+    def getreceivedbyaddress(self, addr, minconf=1):
+        """Get the amount (in satoshi) received by <address> in transactions 
+        with at least [minconf] confirmations. It correctly handles the case 
+        where someone has sent to the address in multiple transactions. 
+
+        Works only for addresses in the local wallet, external addresses will 
+        always show 0.
+
+        addr - The selected address.
+        minconf - Only include transactions confirmed at least this many times. (default=1)
+        """
+        addr = str(addr)
+        r = self._call('getreceivedbyaddress', addr, minconf)
+        return int(r*COIN)
+
     def gettransaction(self, txid):
         """Get detailed information about in-wallet transaction txid
 


### PR DESCRIPTION
Implemented `getreceivedbyaddress` RPC call.

Tested using the code below, as currently the RPC doesn't have a test suite.

``` python
from bitcoin.wallet import CBitcoinAddress
import bitcoin.rpc

rpc = bitcoin.rpc.Proxy()
addr = CBitcoinAddress('ADDRESS')

# NOTE: bitcoin address must be in the local wallet, or it will return zero.

# Without minconf (defaults to 1)
amount = rpc.getreceivedbyaddress(addr)
print(amount)

# With minconf
amount = rpc.getreceivedbyaddress(addr, 1000)
print(amount)
```
