### PR TITLE
Fixing bug where to_bytes clobbers testnet params.

### DIFF
--- a/bitcoin/messages.py
+++ b/bitcoin/messages.py
@@ -33,7 +33,7 @@ else:
 from bitcoin.core import *
 from bitcoin.core.serialize import *
 from bitcoin.net import *
-from bitcoin import MainParams
+import bitcoin
 
 MSG_TX = 1
 MSG_BLOCK = 2
@@ -51,11 +51,11 @@ class MsgSerializable(Serializable):
     def msg_deser(cls, f, protover=PROTO_VERSION):
         raise NotImplementedError
 
-    def to_bytes(self, params=MainParams()):
+    def to_bytes(self):
         f = _BytesIO()
         self.msg_ser(f)
         body = f.getvalue()
-        res = params.MESSAGE_START
+        res = bitcoin.params.MESSAGE_START
         res += self.command
         res += b"\x00" * (12 - len(self.command))
         res += struct.pack(b"<I", len(body))
@@ -74,13 +74,13 @@ class MsgSerializable(Serializable):
         return MsgSerializable.stream_deserialize(f, protover=protover)
 
     @classmethod
-    def stream_deserialize(cls, f, params=MainParams(), protover=PROTO_VERSION):
+    def stream_deserialize(cls, f, protover=PROTO_VERSION):
         recvbuf = ser_read(f, 4 + 12 + 4 + 4)
 
         # check magic
-        if recvbuf[:4] != params.MESSAGE_START:
+        if recvbuf[:4] != bitcoin.params.MESSAGE_START:
             raise ValueError("Invalid message start '%s', expected '%s'" %
-                             (b2x(recvbuf[:4]), b2x(params.MESSAGE_START)))
+                             (b2x(recvbuf[:4]), b2x(bitcoin.params.MESSAGE_START)))
 
         # remaining header fields: command, msg length, checksum
         command = recvbuf[4:4+12].split(b"\x00", 1)[0]


### PR DESCRIPTION
To replicate the bug run the following commands in python console:

>>> import bitcoin
>>> from bitcoin.messages import msg_addr
>>> bitcoin.SelectParams('testnet')
>>> msg_addr().to_bytes()[0]
'\xf9'

Notice that the magic byte is set for main, not testnet.

After my change: 

>>> import bitcoin
>>> from bitcoin.messages import msg_addr
>>> bitcoin.SelectParams('testnet')
>>> msg_addr().to_bytes()[0]
'\x0b'

Notice that the magic byte(s) are correct for testnet.

Happy new years. =)
