### PR TITLE
Add support for Dogecoin

### DIFF
--- a/bitcoin/__init__.py
+++ b/bitcoin/__init__.py
@@ -45,6 +45,27 @@ class RegTestParams(bitcoin.core.CoreRegTestParams):
                        'SCRIPT_ADDR':196,
                        'SECRET_KEY' :239}
 
+class DogeMainParams(bitcoin.core.CoreDogeMainParams):
+    MESSAGE_START = b'\xc0\xc0\xc0\xc0'
+    DEFAULT_PORT = 22556
+    RPC_PORT = 22555
+    DNS_SEEDS = (('dogecoin.com', 'seed.dogecoin.com'),
+                 ('mophides.com', 'seed.mophides.com'),
+                 ('dglibrary.org', 'seed.dglibrary.org'),
+                 ('dogechain.info', 'seed.dogechain.info'))
+    BASE58_PREFIXES = {'PUBKEY_ADDR':30,
+                       'SCRIPT_ADDR':22,
+                       'SECRET_KEY' :158}
+
+class DogeTestNetParams(bitcoin.core.CoreDogeTestNetParams):
+    MESSAGE_START = b'\xfc\xc1\xb7\xdc'
+    DEFAULT_PORT = 44556
+    RPC_PORT = 44555
+    DNS_SEEDS = (('lionservers.de', 'testdoge-seed-static.lionservers.de'))
+    BASE58_PREFIXES = {'PUBKEY_ADDR':113,
+                       'SCRIPT_ADDR':196,
+                       'SECRET_KEY' :241}
+
 """Master global setting for what chain params we're using.
 
 However, don't set this directly, use SelectParams() instead so as to set the
@@ -53,7 +74,7 @@ bitcoin.core.params correctly too.
 #params = bitcoin.core.coreparams = MainParams()
 params = MainParams()
 
-def SelectParams(name):
+def SelectParams(name, coin = 'BTC'):
     """Select the chain parameters to use
 
     name is one of 'mainnet', 'testnet', or 'regtest'
@@ -61,12 +82,22 @@ def SelectParams(name):
     Default chain is 'mainnet'
     """
     global params
-    bitcoin.core._SelectCoreParams(name)
-    if name == 'mainnet':
-        params = bitcoin.core.coreparams = MainParams()
-    elif name == 'testnet':
-        params = bitcoin.core.coreparams = TestNetParams()
-    elif name == 'regtest':
-        params = bitcoin.core.coreparams = RegTestParams()
+    bitcoin.core._SelectCoreParams(name, coin)
+    if coin == 'BTC':
+        if name == 'mainnet':
+            params = bitcoin.core.coreparams = MainParams()
+        elif name == 'testnet':
+            params = bitcoin.core.coreparams = TestNetParams()
+        elif name == 'regtest':
+            params = bitcoin.core.coreparams = RegTestParams()
+        else:
+            raise ValueError('Unknown Bitcoin chain %r' % name)
+    elif coin == 'DOGE':
+        if name == 'mainnet':
+            params = bitcoin.core.coreparams = DogeMainParams()
+        elif name == 'testnet':
+            params = bitcoin.core.coreparams = DogeTestNetParams()
+        else:
+            raise ValueError('Unknown Dogecoin chain %r' % name)
     else:
-        raise ValueError('Unknown chain %r' % name)
+        raise ValueError('Unknown coin %r' % coin)

--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -558,24 +558,44 @@ class CoreRegTestParams(CoreTestNetParams):
     SUBSIDY_HALVING_INTERVAL = 150
     PROOF_OF_WORK_LIMIT = 2**256-1 >> 1
 
+class CoreDogeMainParams(CoreChainParams):
+    NAME = 'dogecoin_main'
+    GENESIS_BLOCK = CBlock.deserialize(x('010000000000000000000000000000000000000000000000000000000000000000000000696ad20e2dd4365c7459b4a4a5af743d5e92c6da3229e6532cd605f6533f2a5b24a6a152f0ff0f1e678601000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1004ffff001d0104084e696e746f6e646fffffffff010058850c020000004341040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9ac00000000'))
+    SUBSIDY_HALVING_INTERVAL = 100000
+    PROOF_OF_WORK_LIMIT = 2**256-1 >> 32
+
+class CoreDogeTestNetParams(CoreDogeMainParams):
+    NAME = 'dogecoin_test'
+    GENESIS_BLOCK = CBlock.deserialize(x('010000000000000000000000000000000000000000000000000000000000000000000000696ad20e2dd4365c7459b4a4a5af743d5e92c6da3229e6532cd605f6533f2a5bb9a7f052f0ff0f1ef7390f000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1004ffff001d0104084e696e746f6e646fffffffff010058850c020000004341040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9ac00000000'))
+
 """Master global setting for what core chain params we're using"""
 coreparams = CoreMainParams()
 
-def _SelectCoreParams(name):
+def _SelectCoreParams(name, coin='BTC'):
     """Select the core chain parameters to use
 
     Don't use this directly, use bitcoin.SelectParams() instead so both
     consensus-critical and general parameters are set properly.
     """
     global coreparams
-    if name == 'mainnet':
-        coreparams = CoreMainParams()
-    elif name == 'testnet':
-        coreparams = CoreTestNetParams()
-    elif name == 'regtest':
-        coreparams = CoreRegTestParams()
+    if coin == 'BTC':
+        if name == 'mainnet':
+            coreparams = CoreMainParams()
+        elif name == 'testnet':
+            coreparams = CoreTestNetParams()
+        elif name == 'regtest':
+            coreparams = CoreRegTestParams()
+        else:
+            raise ValueError('Unknown Bitcoin chain %r' % name)
+    elif coin == 'DOGE':
+        if name == 'mainnet':
+            coreparams = CoreDogeMainParams()
+        elif name == 'testnet':
+            coreparams = CoreDogeTestNetParams()
+        else:
+            raise ValueError('Unknown Dogecoin chain %r' % name)
     else:
-        raise ValueError('Unknown chain %r' % name)
+        raise ValueError('Unknown coin %r' % coin)
 
 
 class CheckTransactionError(ValidationError):


### PR DESCRIPTION
Adds a second optional parameter to SelectParams() and SelectCoreParams() to enable multiple coin support, and adds Dogecoin as an example.

This is currently extremely naive (for example subsidy halving interval is used differently in Dogecoin difficulty calculations), however this is enough to enable basic usage with dogecoind.

Feedback would be greatly appreciated.
