### PR TITLE
[examples] remove hardcoded python executable

### DIFF
--- a/examples/bip-0070-payment-protocol.py
+++ b/examples/bip-0070-payment-protocol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python3
 
 # Copyright (C) 2013-2014 The python-bitcoinlib developers
 #

--- a/examples/make-bootstrap-rpc.py
+++ b/examples/make-bootstrap-rpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2013-2014 The python-bitcoinlib developers
 #

--- a/examples/spend-p2pkh-txout.py
+++ b/examples/spend-p2pkh-txout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2014 The python-bitcoinlib developers
 #

--- a/examples/spend-p2sh-txout.py
+++ b/examples/spend-p2sh-txout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2014 The python-bitcoinlib developers
 #

--- a/examples/timestamp-op-ret.py
+++ b/examples/timestamp-op-ret.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2014 The python-bitcoinlib developers
 #


### PR DESCRIPTION
wasn't running strait off on my mac.