### PR TITLE
Correct error message in ser_read

### DIFF
--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -75,7 +75,7 @@ def ser_read(f, n):
     functions.
     """
     if n > MAX_SIZE:
-        raise SerializationError('Asked to read 0x%x bytes; MAX_SIZE exceeded')
+        raise SerializationError('Asked to read 0x%x bytes; MAX_SIZE exceeded' % n)
     r = f.read(n)
     if len(r) < n:
         raise SerializationTruncationError('Asked to read %i bytes, but only got %i' % (n, len(r)))


### PR DESCRIPTION
Adds missing number of bytes to error message when too many bytes are requested in
a single read.