### PR TITLE
Switch MainParams to inherit from CoreMainParams

### DIFF
--- a/bitcoin/__init__.py
+++ b/bitcoin/__init__.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import bitcoin.core
 
-class MainParams(bitcoin.core.CoreChainParams):
+class MainParams(bitcoin.core.CoreMainParams):
     MESSAGE_START = b'\xf9\xbe\xb4\xd9'
     DEFAULT_PORT = 8333
     RPC_PORT = 8332


### PR DESCRIPTION
Previously MainParams inherited from CoreChainParams, which meant the core main network parameters
were not set.

This is primarily useful if you're, for example, working with more than just the Bitcoin networks and want to use the genesis block hash as a unique blockchain identifier.
