### PR TITLE
adding IPv6 supprt to addr messages with example code

### DIFF
--- a/bitcoin/net.py
+++ b/bitcoin/net.py
@@ -24,13 +24,15 @@ from bitcoin.core.serialize import (
 
 PROTO_VERSION = 60002
 CADDR_TIME_VERSION = 31402
+IPV4_COMPAT = b"\x00" * 10 + b"\xff" * 2
+
 
 class CAddress(Serializable):
     def __init__(self, protover=PROTO_VERSION):
         self.protover = protover
         self.nTime = 0
         self.nServices = 1
-        self.pchReserved = b"\x00" * 10 + b"\xff" * 2
+        self.pchReserved = IPV4_COMPAT
         self.ip = "0.0.0.0"
         self.port = 0
 
@@ -40,18 +42,34 @@ class CAddress(Serializable):
         if c.protover >= CADDR_TIME_VERSION and not without_time:
             c.nTime = struct.unpack(b"<I", ser_read(f, 4))[0]
         c.nServices = struct.unpack(b"<Q", ser_read(f, 8))[0]
-        c.pchReserved = ser_read(f, 12)
-        c.ip = socket.inet_ntoa(ser_read(f, 4))
+        
+        packedIP = ser_read(f, 16)
+
+        if bytes(packedIP[0:12]) == IPV4_COMPAT: # IPv4 
+            c.ip = socket.inet_ntop(socket.AF_INET, packedIP[12:16])
+        else: #IPv6
+            c.ip = socket.inet_ntop(socket.AF_INET6, packedIP)
+
         c.port = struct.unpack(b">H", ser_read(f, 2))[0]
         return c
+
 
     def stream_serialize(self, f, without_time=False):
         if self.protover >= CADDR_TIME_VERSION and not without_time:
             f.write(struct.pack(b"<I", self.nTime))
         f.write(struct.pack(b"<Q", self.nServices))
-        f.write(self.pchReserved)
-        f.write(socket.inet_aton(self.ip))
+
+        protocol = socket.AF_INET
+        if ":" in self.ip: # determine if address is IPv6
+            f.write(socket.inet_pton(socket.AF_INET6, self.ip))
+        else: 
+            f.write(self.pchReserved)
+            f.write(socket.inet_pton(socket.AF_INET, self.ip))
+
         f.write(struct.pack(b">H", self.port))
+
+
+
 
     def __repr__(self):
         return "CAddress(nTime=%d nServices=%i ip=%s port=%i)" % (self.nTime, self.nServices, self.ip, self.port)

--- a/bitcoin/tests/test_net.py
+++ b/bitcoin/tests/test_net.py
@@ -14,9 +14,63 @@ import unittest
 from bitcoin.net import CAddress
 
 class Test_CAddress(unittest.TestCase):
-    def test_serialization(self):
+    def test_serializationSimple(self):
         c = CAddress()
         cSerialized = c.serialize()
         cDeserialized = CAddress.deserialize(cSerialized)
         cSerializedTwice = cDeserialized.serialize()
         self.assertEqual(cSerialized, cSerializedTwice)
+
+    def test_serializationIPv4(self):
+        c = CAddress()
+        c.ip = "1.1.1.1"
+        c.port = 8333
+        c.nTime = 1420576401
+
+        cSerialized = c.serialize()
+        cDeserialized = CAddress.deserialize(cSerialized)
+        
+        self.assertEqual(c, cDeserialized)
+        
+        cSerializedTwice = cDeserialized.serialize()
+        self.assertEqual(cSerialized, cSerializedTwice)
+
+
+    def test_serializationIPv6(self):
+        c = CAddress()
+        c.ip = "1234:ABCD:1234:ABCD:1234:00:ABCD:1234"
+        c.port = 8333
+        c.nTime = 1420576401
+
+        cSerialized = c.serialize()
+        cDeserialized = CAddress.deserialize(cSerialized)
+        
+        self.assertEqual(c, cDeserialized)
+        
+        cSerializedTwice = cDeserialized.serialize()
+        self.assertEqual(cSerialized, cSerializedTwice)
+
+
+    def test_serializationDiff(self):
+        # Sanity check that the serialization code preserves differences
+        c1 = CAddress()
+        c1.ip = "1.1.1.1"
+        c1.port = 8333
+        c1.nTime = 1420576401
+
+        c2 = CAddress()
+        c2.ip = "1.1.1.2"
+        c2.port = 8333
+        c2.nTime = 1420576401
+
+        self.assertNotEqual(c1, c2)
+
+        c1Serialized = c1.serialize()
+        c2Serialized = c2.serialize()
+
+        self.assertNotEqual(c1Serialized, c2Serialized)
+
+        c1Deserialized = CAddress.deserialize(c1Serialized)
+        c2Deserialized = CAddress.deserialize(c2Serialized)
+
+        self.assertNotEqual(c1Deserialized, c2Deserialized)

--- a/examples/send-addrs-msg.py
+++ b/examples/send-addrs-msg.py
@@ -1,0 +1,64 @@
+import socket, time, bitcoin
+from bitcoin.messages import msg_version, msg_verack, msg_addr
+from bitcoin.net import CAddress
+
+
+PORT = 18333
+
+bitcoin.SelectParams('testnet') 
+
+def version_pkt(client_ip, server_ip):
+    msg = msg_version()
+    msg.nVersion = 70002
+    msg.addrTo.ip = server_ip
+    msg.addrTo.port = PORT
+    msg.addrFrom.ip = client_ip
+    msg.addrFrom.port = PORT
+
+    return msg
+
+def addr_pkt( str_addrs ):
+    msg = msg_addr()
+    addrs = []
+    for i in str_addrs:
+        addr = CAddress()
+        addr.port = 18333
+        addr.nTime = int(time.time())
+        addr.ip = i
+
+        addrs.append( addr )
+    msg.addrs = addrs
+    return msg
+
+s = socket.socket()
+
+server_ip = "192.168.0.149"
+client_ip = "192.168.0.13"
+
+s.connect( (server_ip,PORT) )
+
+# Send Version packet
+s.send( version_pkt(client_ip, server_ip).to_bytes() )
+
+# Get Version reply
+print s.recv(1924)
+
+# Send Verack
+s.send( msg_verack().to_bytes() )
+# Get Verack
+print s.recv(1024)
+
+# Send Addrs
+s.send( addr_pkt(["252.11.1.2", "EEEE:7777:8888:AAAA::1"]).to_bytes() )
+
+time.sleep(1) 
+s.close()
+
+# debug log on the server should look like:
+# accepted connection 192.168.0.13:39979
+# send version message: version 70002, blocks=317947, us=****, them=0.0.0.0:0, peer=192.168.0.13:39979
+# receive version message: /pythonbitcoin0.0.1/: version 70002, blocks=-1, us=192.168.0.149:18333, them=192.168.0.13:18333, peer=192.168.0.13:39979
+# Added 2 addresses from 192.168.0.13: 3 tried, 1706 new
+# disconnecting node 192.168.0.13:39979
+
+


### PR DESCRIPTION
Added IPv6 support to addr messages + sanity tests. 
I tested this code against a bitcoin node using a v4 ip address patched to accept v6 addr messages to confirm capability with bitcoind.
I also validated the hex in wireshark.
I added example code used to check IPv6 comparability.