### PR TITLE
Generate low-S DER signatures

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -99,7 +99,6 @@ class CECKey:
         return kdf(r)
 
     def sign(self, hash):
-        # FIXME: need unit tests for below cases
         if not isinstance(hash, bytes):
             raise TypeError('Hash must be bytes instance; got %r' % hash.__class__)
         if len(hash) != 32:

--- a/bitcoin/tests/test_script.py
+++ b/bitcoin/tests/test_script.py
@@ -426,3 +426,11 @@ class Test_CScript(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             CScript([b'a' * 518]).to_p2sh_scriptPubKey()
+
+class Test_IsLowDERSignature(unittest.TestCase):
+    def test_high_s_value(self):
+        sig = x('3046022100820121109528efda8bb20ca28788639e5ba5b365e0a84f8bd85744321e7312c6022100a7c86a21446daa405306fe10d0a9906e37d1a2c6b6fdfaaf6700053058029bbe')
+        self.assertFalse(IsLowDERSignature(sig))
+    def test_low_s_value(self):
+        sig = x('3045022100b135074e08cc93904a1712b2600d3cb01899a5b1cc7498caa4b8585bcf5f27e7022074ab544045285baef0a63f0fb4c95e577dcbf5c969c0bf47c7da8e478909d669')
+        self.assertTrue(IsLowDERSignature(sig))

--- a/bitcoin/tests/test_wallet.py
+++ b/bitcoin/tests/test_wallet.py
@@ -218,7 +218,19 @@ class Test_CBitcoinSecret(unittest.TestCase):
         hash = b'\x00' * 32
         sig = key.sign(hash)
 
-        # FIXME: need better tests than this
+        # Check a valid signature
         self.assertTrue(key.pub.verify(hash, sig))
+
+        # Check invalid hash returns false
         self.assertFalse(key.pub.verify(b'\xFF'*32, sig))
+        # Check invalid signature returns false
         self.assertFalse(key.pub.verify(hash, sig[0:-1] + b'\x00'))
+
+    def test_sign_invalid_hash(self):
+        key = CBitcoinSecret('5KJvsngHeMpm884wtkJNzQGaCErckhHJBGFsvd3VyK5qMZXj3hS')
+        with self.assertRaises(TypeError):
+          sig = key.sign('0' * 32)
+
+        hash = b'\x00' * 32
+        with self.assertRaises(ValueError):
+          sig = key.sign(hash[0:-2])

--- a/bitcoin/tests/test_wallet.py
+++ b/bitcoin/tests/test_wallet.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from bitcoin.core import b2x, x
-from bitcoin.core.script import CScript
+from bitcoin.core.script import CScript, IsLowDERSignature
 from bitcoin.core.key import CPubKey
 from bitcoin.wallet import *
 
@@ -220,6 +220,7 @@ class Test_CBitcoinSecret(unittest.TestCase):
 
         # Check a valid signature
         self.assertTrue(key.pub.verify(hash, sig))
+        self.assertTrue(IsLowDERSignature(sig))
 
         # Check invalid hash returns false
         self.assertFalse(key.pub.verify(b'\xFF'*32, sig))


### PR DESCRIPTION
This ensures all signatures have the lowest possible S value. Where S values are above half the order of the curve, the order of the curve is subtracted from the S value in order to reduce it.

Additional tests for signing added as part of this process.

Low-S value checks have been added to script.py as they are part of script code in Bitcoin Core, but may make more sense in key.py, let me know what you think?
