### PR TITLE
add verifying signed message, using pubkey recovery

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -15,11 +15,21 @@
 WARNING: This module does not mlock() secrets; your private keys may end up on
 disk in swap! Use with caution!
 """
-
 import ctypes
 import ctypes.util
 import hashlib
 import sys
+import bitcoin
+import bitcoin.signature
+
+_bchr = chr
+_bord = ord
+if sys.version > '3':
+    _bchr = lambda x: bytes([x])
+    _bord = lambda x: x
+    from io import BytesIO as BytesIO
+else:
+    from cStringIO import StringIO as BytesIO
 
 import bitcoin.core.script
 
@@ -128,6 +138,53 @@ class CECKey:
         else:
             return self.signature_to_low_s(mb_sig.raw[:sig_size0.value])
 
+    def sign_compact(self, hash):
+        if not isinstance(hash, bytes):
+            raise TypeError('Hash must be bytes instance; got %r' % hash.__class__)
+        if len(hash) != 32:
+            raise ValueError('Hash must be exactly 32 bytes long')
+
+        sig_size0 = ctypes.c_uint32()
+        sig_size0.value = _ssl.ECDSA_size(self.k)
+        mb_sig = ctypes.create_string_buffer(sig_size0.value)
+        result = _ssl.ECDSA_sign(0, hash, len(hash), mb_sig, ctypes.byref(sig_size0), self.k)
+        assert 1 == result
+
+        if bitcoin.core.script.IsLowDERSignature(mb_sig.raw[:sig_size0.value]):
+            sig = mb_sig.raw[:sig_size0.value]
+        else:
+            sig = self.signature_to_low_s(mb_sig.raw[:sig_size0.value])
+
+        sig = bitcoin.signature.DERSignature.deserialize(sig)
+
+        r_val = sig.r
+        s_val = sig.s
+
+        # assert that the r and s are less than 32 long, excluding leading 0s
+        assert len(r_val) <= 32 or r_val[0:-32] == b'\x00'
+        assert len(s_val) <= 32 or s_val[0:-32] == b'\x00'
+
+        # ensure r and s are always 32 chars long by 0padding
+        r_val = ((b'\x00' * 32) + r_val)[-32:]
+        s_val = ((b'\x00' * 32) + s_val)[-32:]
+
+        # tmp pubkey of self, but always compressed
+        pubkey = CECKey()
+        pubkey.set_pubkey(self.get_pubkey())
+        pubkey.set_compressed(True)
+
+        # bitcoin core does <4, but I've seen other places do <2 and I've never seen a i > 1 so far
+        for i in range(0, 4):
+            cec_key = CECKey()
+            cec_key.set_compressed(True)
+
+            result = cec_key.recover(r_val, s_val, hash, len(hash), i, 1)
+            if result == 1:
+                if cec_key.get_pubkey() == pubkey.get_pubkey():
+                    return r_val + s_val, i
+
+        raise ValueError
+
     def signature_to_low_s(self, sig):
         der_sig = ECDSA_SIG_st()
         _ssl.d2i_ECDSA_SIG(ctypes.byref(ctypes.pointer(der_sig)), ctypes.byref(ctypes.c_char_p(sig)), len(sig))
@@ -185,6 +242,106 @@ class CECKey:
             form = self.POINT_CONVERSION_UNCOMPRESSED
         _ssl.EC_KEY_set_conv_form(self.k, form)
 
+    def recover(self, sigR, sigS, msg, msglen, recid, check):
+        """
+        Perform ECDSA key recovery (see SEC1 4.1.6) for curves over (mod p)-fields
+        recid selects which key is recovered
+        if check is non-zero, additional checks are performed
+        """
+        i = int(recid / 2)
+
+        r = None
+        s = None
+        ctx = None
+        R = None
+        O = None
+        Q = None
+
+        assert len(sigR) == 32, len(sigR)
+        assert len(sigS) == 32, len(sigS)
+
+        try:
+            r = _ssl.BN_bin2bn(bytes(sigR), len(sigR), _ssl.BN_new())
+            s = _ssl.BN_bin2bn(bytes(   sigS), len(sigS), _ssl.BN_new())
+
+            group = _ssl.EC_KEY_get0_group(self.k)
+            ctx = _ssl.BN_CTX_new()
+            order = _ssl.BN_CTX_get(ctx)
+            ctx = _ssl.BN_CTX_new()
+
+            if not _ssl.EC_GROUP_get_order(group, order, ctx):
+                return -2
+
+            x = _ssl.BN_CTX_get(ctx)
+            if not _ssl.BN_copy(x, order):
+                return -1
+            if not _ssl.BN_mul_word(x, i):
+                return -1
+            if not _ssl.BN_add(x, x, r):
+                return -1
+
+            field = _ssl.BN_CTX_get(ctx)
+            if not _ssl.EC_GROUP_get_curve_GFp(group, field, None, None, ctx):
+                return -2
+
+            if _ssl.BN_cmp(x, field) >= 0:
+                return 0
+
+            R = _ssl.EC_POINT_new(group)
+            if R is None:
+                return -2
+            if not _ssl.EC_POINT_set_compressed_coordinates_GFp(group, R, x, recid % 2, ctx):
+                return 0
+
+            if check:
+                O = _ssl.EC_POINT_new(group)
+                if O is None:
+                    return -2
+                if not _ssl.EC_POINT_mul(group, O, None, R, order, ctx):
+                    return -2
+                if not _ssl.EC_POINT_is_at_infinity(group, O):
+                    return 0
+
+            Q = _ssl.EC_POINT_new(group)
+            if Q is None:
+                return -2
+
+            n = _ssl.EC_GROUP_get_degree(group)
+            e = _ssl.BN_CTX_get(ctx)
+            if not _ssl.BN_bin2bn(msg, msglen, e):
+                return -1
+
+            if 8 * msglen > n:
+                _ssl.BN_rshift(e, e, 8 - (n & 7))
+
+            zero = _ssl.BN_CTX_get(ctx)
+            # if not _ssl.BN_zero(zero):
+            #     return -1
+            if not _ssl.BN_mod_sub(e, zero, e, order, ctx):
+                return -1
+            rr = _ssl.BN_CTX_get(ctx)
+            if not _ssl.BN_mod_inverse(rr, r, order, ctx):
+                return -1
+            sor = _ssl.BN_CTX_get(ctx)
+            if not _ssl.BN_mod_mul(sor, s, rr, order, ctx):
+                return -1
+            eor = _ssl.BN_CTX_get(ctx)
+            if not _ssl.BN_mod_mul(eor, e, rr, order, ctx):
+                return -1
+            if not _ssl.EC_POINT_mul(group, Q, eor, R, sor, ctx):
+                return -2
+
+            if not _ssl.EC_KEY_set_public_key(self.k, Q):
+                return -2
+
+            return 1
+        finally:
+            if r: _ssl.BN_free(r)
+            if s: _ssl.BN_free(s)
+            if ctx: _ssl.BN_CTX_free(ctx)
+            if R: _ssl.EC_POINT_free(R)
+            if O: _ssl.EC_POINT_free(O)
+            if Q: _ssl.EC_POINT_free(Q)
 
 class CPubKey(bytes):
     """An encapsulated public key
@@ -203,6 +360,30 @@ class CPubKey(bytes):
         self._cec_key = _cec_key
         self.is_fullyvalid = _cec_key.set_pubkey(self) != 0
         return self
+
+    @classmethod
+    def recover_compact(cls, hash, sig):
+        """Recover a public key from a compact signature."""
+        if len(sig) != 65:
+            raise ValueError("Signature should be 65 characters, not [%d]" % (len(sig), ))
+
+        recid = (_bord(sig[0]) - 27) & 3
+        compressed = (_bord(sig[0]) - 27) & 4 != 0
+
+        cec_key = CECKey()
+        cec_key.set_compressed(compressed)
+
+        sigR = sig[1:33]
+        sigS = sig[33:65]
+
+        result = cec_key.recover(sigR, sigS, hash, len(hash), recid, 0)
+
+        if result < 1:
+            return False
+
+        pubkey = cec_key.get_pubkey()
+
+        return CPubKey(pubkey, _cec_key=cec_key)
 
     @property
     def is_valid(self):

--- a/bitcoin/signature.py
+++ b/bitcoin/signature.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2012-2014 The python-bitcoinlib developers
+#
+# This file is part of python-bitcoinlib.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of python-bitcoinlib, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from bitcoin.core.serialize import *
+
+# Py3 compatibility
+import sys
+
+if sys.version > '3':
+    from io import BytesIO as _BytesIO
+else:
+    from cStringIO import StringIO as _BytesIO
+
+
+class DERSignature(ImmutableSerializable):
+    __slots__ = ['length', 'r', 's']
+
+    def __init__(self, r, s, length):
+        object.__setattr__(self, 'r', r)
+        object.__setattr__(self, 's', s)
+        object.__setattr__(self, 'length', length)
+
+    @classmethod
+    def stream_deserialize(cls, f):
+        assert ser_read(f, 1) == b"\x30"
+        rs = BytesSerializer.stream_deserialize(f)
+        f = _BytesIO(rs)
+        assert ser_read(f, 1) == b"\x02"
+        r = BytesSerializer.stream_deserialize(f)
+        assert ser_read(f, 1) == b"\x02"
+        s = BytesSerializer.stream_deserialize(f)
+        return cls(r, s, len(r + s))
+
+    def stream_serialize(self, f):
+        f.write(b"\x30")
+        f.write(b"\x02")
+        BytesSerializer.stream_serialize(self.r, f)
+        f.write(b"\x30")
+        BytesSerializer.stream_serialize(self.s, f)
+
+    def __repr__(self):
+        return 'DERSignature(%s, %s)' % (self.r, self.s)
+
+
+__all__ = (
+    'DERSignature',
+)

--- a/bitcoin/signmessage.py
+++ b/bitcoin/signmessage.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2013-2015 The python-bitcoinlib developers
+#
+# This file is part of python-bitcoinlib.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of python-bitcoinlib, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from bitcoin.core.key import CPubKey
+from bitcoin.core.serialize import ImmutableSerializable
+from bitcoin.wallet import P2PKHBitcoinAddress
+import bitcoin
+import base64
+import sys
+
+_bchr = chr
+_bord = ord
+if sys.version > '3':
+    long = int
+    _bchr = lambda x: bytes([x])
+    _bord = lambda x: x
+
+
+def VerifyMessage(address, message, sig):
+    sig = base64.b64decode(sig)
+    hash = message.GetHash()
+
+    pubkey = CPubKey.recover_compact(hash, sig)
+
+    return str(P2PKHBitcoinAddress.from_pubkey(pubkey)) == str(address)
+
+
+def SignMessage(key, message):
+    sig, i = key.sign_compact(message.GetHash())
+
+    meta = 27 + i
+    if key.is_compressed:
+        meta += 4
+
+    return base64.b64encode(_bchr(meta) + sig)
+
+
+class BitcoinMessage(ImmutableSerializable):
+    __slots__ = ['magic', 'message']
+
+    def __init__(self, message="", magic="Bitcoin Signed Message:\n"):
+        object.__setattr__(self, 'message', message.encode("utf-8"))
+        object.__setattr__(self, 'magic', magic.encode("utf-8"))
+
+    @classmethod
+    def stream_deserialize(cls, f):
+        magic = bitcoin.core.serialize.BytesSerializer.stream_deserialize(f)
+        message = bitcoin.core.serialize.BytesSerializer.stream_deserialize(f)
+        return cls(message, magic)
+
+    def stream_serialize(self, f):
+        bitcoin.core.serialize.BytesSerializer.stream_serialize(self.magic, f)
+        bitcoin.core.serialize.BytesSerializer.stream_serialize(self.message, f)
+
+    def __str__(self):
+        return self.message.decode('ascii')
+
+    def __repr__(self):
+        return 'BitcoinMessage(%s, %s)' % (self.magic, self.message)

--- a/bitcoin/tests/data/signmessage.json
+++ b/bitcoin/tests/data/signmessage.json
@@ -1,0 +1,1002 @@
+[
+    {
+        "address": "1K5Z1nxN4mjUgCLpSXMRkeZxuAMpbn2CQB",
+        "wif": "KwfJTiKdcjNMjBu4ksgGd21EZXz6JomoZNbirP3nfd3K9ZMXMEUi",
+        "signature": "H8PgOb/liZzt3QQHJn9kLBqH7E/i+SC6JTwYGtdNdOjnXzFqXnHMZqP7oZ1wb1QiQ3H/kF8xC9Yx7pK9ddlx8TA="
+    },
+    {
+        "address": "1CzDCcHkJq2cH9bMWwQgaJsgSxPL8cw3ex",
+        "wif": "L38oXgJ9vuatxjZzU99tBn9ggwyL2mJa1iGxBw34m5tgvxkbimAJ",
+        "signature": "H8p9zchgGjDqXjL/RRRFCxdmrszMBhOM5H3/7guzGPrpPpK98PSFxPPC+bbB9qKFxIcRqEwmTs0CyOh2L+NtqlA="
+    },
+    {
+        "address": "1CaKn6rs61k5C62kwdqzHvDiJa4aijiiSZ",
+        "wif": "Kyri8mmjXpzwBNz8HsUV949gNt6BXD5NNkYCBprMUJTTyi8MgCyH",
+        "signature": "H2CmJhzcOW9KOBVWT4xhiyGpXz7fvjgjsf4IdXMNdif761byosI2Qtk8firpHF0euOEGpE6DyogbWzhPNKuO6kw="
+    },
+    {
+        "address": "1LoGaos8SGCFVx9vMQP2kMnJuYN5gxpogF",
+        "wif": "L4abGhH51nRffuHr6zsH9NXyKtpX3YB52bUiF95n2WZdLVNAA278",
+        "signature": "H1n6031DKK+4HdoyNNk6U5bgqd/vk/as2SfR9WyHcyI/J86xQrnHTuqw9hJ5BuF1sAq17euETP3By/FA7IJsANM="
+    },
+    {
+        "address": "1CHrifiFz2sGeBKM6P98yQuPboUWrpH75B",
+        "wif": "L3434z4bHCX1Z3Z9jsEyZoaex19CZh97xhUfbrvwBYpw6sCSCAvX",
+        "signature": "H4fNh9cxEL7oyv0Sxc/qj65EBfyulYgfhu31dMHqMJEFEr///pYndzrVGE5Ncf4hAi/kNY/gj+CT/E3GDaKtlhQ="
+    },
+    {
+        "address": "13KyVsmGYSopgmsK1rzWah73HVUSPfQZAZ",
+        "wif": "L1trSS5d8Vk6koakoab2M1ZE9CfKyKMzQTLLXacR8Ez9hRUbX7pL",
+        "signature": "HzOwq2BnqAEsMzusoXjPATGMOX7hTKR63wc1LHU69GYi3PtsYt26O5s4i0K/ro6y4F/62Lb93n5qsxUQ2ZDXklo="
+    },
+    {
+        "address": "148xViYbEoBG5QjxWT2sUG4nehVhvng5Fq",
+        "wif": "L1oLA8E5Narp9NDWtv2SQ1z32iL9gfy7nx9q38vbd324JbrUdHyW",
+        "signature": "IGFQhE+R0buv+a8QAiK7dfZ7oMlZVFJAkRpm572Ir53fWGT510QxGp5uHyc0x3Pcrn6FMSndml5jOU+exVfST6c="
+    },
+    {
+        "address": "1KMHXVGbtwAJKbWcqyk6amSBBXXvHdcJmv",
+        "wif": "KzuoZykvmrjs2nkgVCdC869bJ6b33kasqSc2XzVL2XFnY5JJcbL7",
+        "signature": "IDAweD2d6rN7d3ALWkf/pfyAHgxm955Uj8yAZaLDb5un5WDcdnu/Xy7YsY65h8Os8TFmJNN+nkPkxKapjr0fUaY="
+    },
+    {
+        "address": "1KL8oHatYi8gT2sXR8z7hD64Na1TNM3T5H",
+        "wif": "L4ZEN4VFWDLFDoruqJYYNMzfqYo8Y6ZcwG3JEX2o54Rtt1sD58ti",
+        "signature": "H+MfZsyz63oBkVl0VyrE2e3I8i//v8VqMzN6KvOnHjcnyr2vzX6VPVAZfvPxnqKlGsqSZ964sk78HYBByecFqZ0="
+    },
+    {
+        "address": "122A264VaC4iBS8oKasjmFsRuNUXmoiJDN",
+        "wif": "Kwhh9C4Fq7bKS3SL9DMtRkk7DuBGkjjSt3dFYFc92SD8Wt2eqX82",
+        "signature": "IBEyPRsRkqzVMcH7aXKLdEButyJRDM4f3VB5Z8eevmTZgyDGmTXkK+V6aZNPWiDmhANSzU4J700xaw1DV4bPBX8="
+    },
+    {
+        "address": "1gZubzqPigT2W1NEHhTQ6vRc9m9UUQiRN",
+        "wif": "L3hEeVxBHa6VQwVcdxLPpWPaqHr3krDU88QqRUEVZbRCHE5H3eAt",
+        "signature": "H9ZBAPbPUEVnyflsNjCzYg2XYiqypngwHLzi3EE1ErnlWofCy71cFFyxy8aERAzrqkDRzdmVTh+AxvWaJfPxpPc="
+    },
+    {
+        "address": "1JyAmHFZRYughnxcyySEKESDxDHPCBbGtD",
+        "wif": "L1KiFe2UCpt7SZik6h4Y6ojNgyZYiGPaXgQbNTCAR5uAhvEMoCWY",
+        "signature": "IOSbmEDXRNUeftut3RCTHM5yHMTMVArVICXWQg21AHKfBkPjSp4se7JkSYZ3E2CvtckMRUZTn0IF+ZJVwevpQKo="
+    },
+    {
+        "address": "1KRLy3r2ukguk9qdtC7YC69eBMb515dyMp",
+        "wif": "L1mtAJyN4z5FWsazodkFeXpMFQzniYoMy4srniZgcmZVDXwV5E8w",
+        "signature": "H8ed1b9hzu3KnqHhgDqsNyb70lsrujLcW31llmVIKaIUPb1odcVl860gwF5z93YQnwqyRezabnRFJJGFRPDTDhc="
+    },
+    {
+        "address": "1GPXPQ5WZuVUtREKavM83NCTuVubd73MYC",
+        "wif": "L5FmANAjEwj7pooNDrRw1bQFw1MvBH1gYCSCPCGgKCfA1VtvKEoF",
+        "signature": "IB+ktPQT3jwHFniWn1lfrF+vDAQpP4E9aThlLniK9uxTKlySNA9ArOB/7QI0Fq16NN7jkFL8LhEw2u8iUDeSdj0="
+    },
+    {
+        "address": "187iiiy3P9EiEEo5xFQQmeXnc4Mh93oWqj",
+        "wif": "L2egcHyb5jzppeGWYPhKXeYj3BNRtBej7FmqQi3hgijdNTsjPcbw",
+        "signature": "ICnsyyD4NdaEbCzFJ6+a+iqYDyi2TZsFU5fs4BVxYwXPCf+Fs/bXfJkgewneXubkOKOweGQta1dGH6PTv4X711I="
+    },
+    {
+        "address": "1KYF4kyD75Hqr4bszgT7M2b3dffnpjfNKk",
+        "wif": "L2kZjNrfJPv1tj8bVUFLkKBVWSWj5M5cSHWhhM8tTTaxefE1ZpPL",
+        "signature": "H+7FBxzH+KT1Y4kbzGyO8/uVTpySdrEf5lSMkLy+Nlr3HK5ySF3bRX8GWN68nABsf3JvGbF7HGNeG5tnF1o0VAY="
+    },
+    {
+        "address": "1CMrqDTQu6WUrFjJFPHLEESTwLsZ5uDYCM",
+        "wif": "KyTNcK1xm26b1tcGnC1nAZJHGro54WuatdEjxSGDs5s6BKgL5sht",
+        "signature": "IHKfBFZiHTmIlsrzxc3Wj8AvkpnQMKpg7mefJjxkT0qiYTNkbXqyyoWEvB6N4f56M9Ar+mw0nhK9J4CjC0wdCVs="
+    },
+    {
+        "address": "1PDFHCWhgfrx3ZU1UWimUTpnyRjhjbhxkX",
+        "wif": "L2H82fpnWjpQUr3s5CJ92rDfj8P3JFKgLywxbdKGjVSNcbk3gMfA",
+        "signature": "ILT3UNo/GS9MsOcbie5vVSUQUXnWKfCLioc6DxbbYPVxVvfuaWoJqnzTBVqXmyfrV942yjMEFoYjZ1U6SaeH+M4="
+    },
+    {
+        "address": "1MG5ETsNTUhvg6av8A8jddJJ4gRk6YKnWH",
+        "wif": "Kx4GGUhbZK1fDunwjsfTSJpq37yoEwb6h6e7k2RxeYLBPnd8KJtC",
+        "signature": "IDz+MJgPs7da/lBskPUibOfd0Ht0u5VGYAVeOQvygnv93JrG5REUHY5WdK5CCOKA0S7qW9zsLVAcrHSzHyqac34="
+    },
+    {
+        "address": "181pMcFzbLTcmUP8z1XSmUcNZWKsPBBxpi",
+        "wif": "L1Pf9nn3SYw7YfWgWygNDD6eMd3DKM1BbZKiLKAHmyGfh7Doibtb",
+        "signature": "H7/BVLl33yfaldy/dOM4at3y+tjnGITH/aJHr1s6tN5BSbXue9cmSe6OVWv7jbwnFa0DrlNLY9gOZzJuY5bDsQI="
+    },
+    {
+        "address": "1MN4DL4mQWxsk3mfUYZ8ic5uHEUAemWSjb",
+        "wif": "L2MUxGLQrXJaTSS9ou2PSEcWrjtDQE4BQTF6EL7fKwQM5VwJzcCR",
+        "signature": "Hz2nR9Uv1yfpxl8eVZhhqOOmJvODcCG14K/2rgNyHkop8dDpJi2HHwGb4YII0LeNBv/LK9O+J12aNOcyMzKMD2M="
+    },
+    {
+        "address": "18XZkC4CkL6bwLHy3zhzLyPB4xh7f4h23D",
+        "wif": "Kxwq4ssi3vmmgWPoRafS6UYD3QSnMT4SRtiCaWSNWKM6ZBiEqvc4",
+        "signature": "H+MQJjqlSgG+mAgI/8JX+VE40E5t1w5YSGBiMbUigphjz1zQOHjK7HW5yKHwsO3byB0O1dQAicPNtITq8J14K4U="
+    },
+    {
+        "address": "1AyXZ9RYp9pE1qsR1rqivB3edJXP8GWyiP",
+        "wif": "L2ms2rjGrRttzSdqynwgSDV76ED3WmPFM2YYqHGzHNaZiVQzsCg5",
+        "signature": "H0LCyCPf+NlA4LL850YIHIVpqhN/ImUFy9oZIAR+H9Op4CNUVu87Ee0fbSoikpmcGELWIaFM0WoUyGk8Vi7uNrY="
+    },
+    {
+        "address": "1DB7NMtNRtP3QdAtNaUjwM86HvnfCC5AzZ",
+        "wif": "L5kcHFsH2jNGoU6J4BqNy8g8Dao85VjhYa8ccxA3stSJqpdVYMzu",
+        "signature": "IKPAmB40MTsgd4npAEAO7AskWDH7K6hqRPI/z5tG5VS53ESBqnprF/kHmPPot8uRPNoXHkFuYxQZOyMXX7lJEmM="
+    },
+    {
+        "address": "15BJrja5LsFAchqUg6rTnQMLnihiMLxhJo",
+        "wif": "L4YMEXuLecrzrfuypwtVdaChhmCj64X2MkETUAPg6DtRiuVGFjja",
+        "signature": "H21Xzc40Kr45kx5oiiC3qgSr973Vtn+mvIscnPObxtmrDtSICoF0QbiTVUE0CZu/x19WOA4omjb7EBMZ44V6ovY="
+    },
+    {
+        "address": "1A7Tfi8FVpfDKJZWBrsBWjze3nnCV4ZfXL",
+        "wif": "L1Fd1jF6u1vbPeNcTxVn1KTab4smbqFj6gVZ6jtXAbrvdzcytvHB",
+        "signature": "HxO5kpb4UlAhii8eVHxuw2/aSiqR+KxVG/WZH5Qy2epRHrOIsI5DJmJ1Yd04PK4ishnLFXlc1MqlIIImgQWogJo="
+    },
+    {
+        "address": "1DHwsc3aHztCyqaPG2EQ7Jf91CAqxGGYkM",
+        "wif": "L2E55PLU9t4bcgVYm7LwCR7E2YFEdtJo7C1EJjzsdiRGz6geXy2X",
+        "signature": "INcHA2+Wvpi2RM800ykYI5+CphMqC9eXYdtMeidQTWwAM9tuKG5/zPzM4dGYlWNF1r+aoISFv+yFUkthUbnoH7o="
+    },
+    {
+        "address": "1LjwcSHxLfZGh84Scuazu7iumbUq9dQ2eq",
+        "wif": "L2x6KEbRpmQLoCxaCPCYtwc9fjjxSr25hQmH5hHgnG7eUahRoKs3",
+        "signature": "H9EG7E88+jhJgO2/bfYBNf8da9J8tUs7ziV3XwojZ4msTppUA+ldVIKjdP6fhucji29LUHbAWrbpYPjEenrz6ow="
+    },
+    {
+        "address": "18bAFKGHtzE3ZB4zR4XX1c9X114jchhHDw",
+        "wif": "L2Qe8XEhc8CNbckzB7F3RMXemh9ntDQyVC1wR1Z3LPxTDRmVj9ER",
+        "signature": "HwJXfWR2WqUqqtrkIpJRQK2OwStkfLvBAq4gDM9fdiwpm3rcPPS7pgIhhONr6oE+Ea1FdWB8D7Ui4st/PFgxZxc="
+    },
+    {
+        "address": "15LzGqNqeJ1doaQ8j9SdJ5D9UtekGgvVnD",
+        "wif": "L1Pypc7vL1kifCzY12KzhvcpqxUwNC1LUA8ui7tFuE9Wyhun7hw3",
+        "signature": "H9ORqWL1Jpl682gVwZ7rNXvKiwzXX4/b6+cu7L3vtliwKaxLkgO2xyHs87SBah33Vog0kJZaK76jA4Kr7eNqR7E="
+    },
+    {
+        "address": "1B1KnUWgErwNPy5ddyTFHUimzKSFPp847h",
+        "wif": "KxTCujUdoKXVe9HGPR5id85YYf8HnaRxYc66JVA51G4uoSDgxY8b",
+        "signature": "IOFXUdyOgYLMFfOBLlzSQL1/JLQ89Sb8eOAH0pZCvJ3m3CuLsbtd5YvmA1J8u1fCjrp9dkK/VjjsgrB1zuaahco="
+    },
+    {
+        "address": "15ymYptFaP9TvkS7AJY8LBUD4X8215Aeyq",
+        "wif": "L25fWioivsYomokpcyhBoNGrSKoCw6J6wGvpanr2tizMPtB8Wbze",
+        "signature": "IEXYj7Be6qpmhNBqLf/hauqT3M4Xq2h0XeaBPhlJFBX2EPdR/s9qPTJ8lnPHCOzAPJXcSWK2ZqSCjCr9lTBJAhM="
+    },
+    {
+        "address": "172pMom9HYExjrFwaDLXpMUePqG8koLQcc",
+        "wif": "L4FYTnstvkrUBfC3dRqNzra3zU6RUFXR7AGCFF3ifKuQ1ggKrmTs",
+        "signature": "H8eiIuaUp7Rr6frtypvjVtsSAyvCGSg0VbymjkYHBMIvj+rcHR8KCCwIZ/v8XQDGMjz7t9o5BiEJLjD2gtDd3qE="
+    },
+    {
+        "address": "1pzJeXN3h8kJ67kfF8nkKbcEDatX2bwVQ",
+        "wif": "L2zY8FHZFgmRKULk9YzaLBb8XTdjfYtLtX1AufjkZaZTpjUU4xAS",
+        "signature": "IOYT2uNuPUGt6SzHG6m/2aGswjcR/A9NX08x2Pjq5PY//Dwj4PStj/4ExQCPUdZPd5TgD2JSzQYjAa0qJOvzO7U="
+    },
+    {
+        "address": "1GqaGRFZi5gTxK2BHNTEDKs1GxnPL2r55Z",
+        "wif": "Kz2V929m1nnhmTa8HLKZDE8Letq2Z5J7jXCKs7d5ccRga79nzcoB",
+        "signature": "H3BoJag7tI17tqi7gGXe6ki+cM4YyWq8m5HVmcHXwkziGCJ2a+qhl5wVigYhUwWkNtQU5+fjz5tzlEoJD/UjccY="
+    },
+    {
+        "address": "143F3q22Cpdx7cPMsbaqkyLYyHf8aJadLr",
+        "wif": "KzSoJeJXBTwsdZZiKuiGVboWa5HyFD8eekNEq23iTGg6oQEDZYvu",
+        "signature": "IAvp0Nl9FVODboh4mwyvGwLQtSxKKb+XXG6xt10h0AJHV3bD4AIzKjPCzmt4uDykg9hxJchnbtoJA/gw1zJyLq0="
+    },
+    {
+        "address": "12tkcUE2kvBayoSjeuU2naodL7byN3Zah3",
+        "wif": "KwwZGgUaHTZMcwiB8G8vCoKqfDRShoffxEJoziwzQUcSFuKVUzEk",
+        "signature": "HyqO1n06z2DQfoD9ulhjVe+M0Isk6hWr9IYvgQTK+IOfUENjxbR+y3FBcxFOFvppQ8Ff/IzZ0e5anX3BIrmRHeo="
+    },
+    {
+        "address": "12KPhtXmbSm6zJypCMQ6W4iX547cyQWrVv",
+        "wif": "L58mKsU6g8kK5frb1zxkqZnJc4uMC7BoPY87AXubScJVU1RCB3xk",
+        "signature": "ICPqjIvbFxi5HWzWVkvzIfACzRqIL4IXyNBYjC15f3gOQsyp5UxWPshGIHcVbHV1oRsJt6usc//2okQJ/OcFx30="
+    },
+    {
+        "address": "1MW1eYaV15DPQjUXzHUBDzQarPRxT8vzct",
+        "wif": "L43Zw8EYTaDYMmQbTU4oqTPqyDk5ywtHSMPWwUJz6xKiXGr6tfHd",
+        "signature": "IFBIz9Ba3JcgBga1K5dJMp4HAgOQg0HJIfzdUTDkeRsbf/+afc3C8p37eHUjgTWQTtRRjQ3bAzgH5QRLuNfhZBA="
+    },
+    {
+        "address": "1EeNpNQZDuHXasaKH78UdVWvi3C2vkXSJe",
+        "wif": "KwGV2LuFzAD9HEnv71tHrse6oVFxQ9PUYHLb2rLfG3pD45fdMC9j",
+        "signature": "H8kJAwrvo5ngwG0u0XGTrHOPM9u9QOI5QGTZwRKngUCbS2jw5v6KpBaLoEdb05BWdgZBgQ8ETP/qZdeIenXcOc0="
+    },
+    {
+        "address": "18uGpu2XHtpaKbV398cA5z3ztQR7VJPmwi",
+        "wif": "KzUNtCXbP6sJPRGpLVUZvjAscSdfWj7eEZCrMasydTvsH2UMYmdh",
+        "signature": "H+3BME1BJ0fXlK65/PZS9ttp/uYxyS7dSQiD68eOVzHufjsbcU9l1nKivRpnPRcElXJnN/LMSPIM9YgVmzA/Mxs="
+    },
+    {
+        "address": "17isxDy9b3ruvwzyPfJ8eAq3rAAXzRVCkH",
+        "wif": "L18vqXW83WLDdD1HBncdvoK4rjXTwLaHTb5w5gcxzGpXXuLN3fRo",
+        "signature": "H+humGt3Un1m68TtIoWZLvIWnWx6hb1cQslMzAg0ZghGCDvrN2N/3VmshUxZLaC9nwFUogWUL/gfkKWb1XpgtUo="
+    },
+    {
+        "address": "123Dwfp6RDMuqk4PNuQZ1FLhACnNgNe4FY",
+        "wif": "KwkrkDQQSAx85neUp29aHyfM3S9LVT3g6D8tZuFQ5FTX9dvBNURP",
+        "signature": "H0OSxW7HEcqLya7LKWAWQir0FZDH9WCwJcbuMrEUkbxLJs+KXmb2NKipjTFxEni5ovi1q6VfrCZbw7U1WbVU/lQ="
+    },
+    {
+        "address": "13rt73QHSjHDRHLFJ2QLNDC9MvL8tDg8dK",
+        "wif": "KzzQA1fHTjVwHXWjjUwgaPLvZSS9NUHHSHwwvB26BJtrGUdTjLJ8",
+        "signature": "IBAvh4HyS72mTOi9jaB2z/rFgiuU/G8aW3HbVqhYhdKPSw73bhlL50E4Kz7EU27FUZ0B5j93Om7wNRBEXD8p/eo="
+    },
+    {
+        "address": "1Hz3b39PfCMnEUiDh1TdRzAEhShaweAQps",
+        "wif": "Kxaz6CV1vk9P3H86XH3ne1eucdHCzLG2bmrKVSpyBGftDwceMs16",
+        "signature": "IGtqzxiqbzujQQSurkbuT9fkPUblzMt43uwWz1+Koq1w8izU3y2sWtrYFWwXCP/DUdM8xt15ahXMdu9JYh34wo8="
+    },
+    {
+        "address": "19wXdV8ceRQVfB2LyTaGqd5NrKhbkMPSWp",
+        "wif": "KyJQ6zs2bVSBF4jGm6sP5WkTFc4HTFx1gp3J84bxwMvdv9CmtU5x",
+        "signature": "HyxjlzS8Se/VLRVLjjp0g+eorFPhF7XDlRBVq2uL1cea66hH5TS5K2toUBxhh57NsmN65cSHKVAvUMocsDXwx1c="
+    },
+    {
+        "address": "13Vp66YYuiMvSALRQwXVXWPVsY58SGHWwm",
+        "wif": "L19dLxXSaXrfRDEuE7TvBoTdSnCEgg7ngfv6nQzJwRtcKFCF9hMA",
+        "signature": "H/0jnELT8Y7awiiy7auv3MYzmvdZW/WY6Me7DA1K3vZW4P/nNPEvl8e+VbcamwOumRWyHsJFfCe+uzpExNQ3Gvs="
+    },
+    {
+        "address": "1Dh4SH1wqezkvWr6H7w3g8eCEMAqFfxQVp",
+        "wif": "L1ScH9BHd8FuKTP9qYtqmgMw1ejbVUZgCzrFK8FXwdbubzr3ewgR",
+        "signature": "H8+FVphkG5UykflJdRQECvjyjm4oKVT9PxZd6guGBeT3trV3a90nnDtBy9Xeb9qsabwOvh4vdRfO45EXr695s1g="
+    },
+    {
+        "address": "1LjrTEqRbTsHFQfrLsB9wZBoH9RqZSyKj2",
+        "wif": "L21cHbM8Ef2GxhjdXNB5Z37fPVdDYZ46HtxLj6gTBQ1oXLfXnSZF",
+        "signature": "HxDQz5Kc9yO9k29rCBVL9tBAmRSrf31vyT6v77xVfYXe2GxxE/QMVcdGUTUgcF4PWkvLOhC93d50Wm+ddv4+3XU="
+    },
+    {
+        "address": "1MGCkQ8sn9SyfL5HknjSZCFaLvExMpCAMh",
+        "wif": "L4YurUpTav4iqSqoqWmg9XAg2V9EjecXm4cHXKeJXz46agtBpqNx",
+        "signature": "IBQgu8Ap+KY7v88KOzCWiB9ttMH2/nZmAMOcFTfh2lw0nQ+hqBq5GRyIqMb44kcM+eTUzIl1DEjQStjMNK4HTc0="
+    },
+    {
+        "address": "1GfJB8239xR8F35TmdjrGo2SY8MAupJrLn",
+        "wif": "L4hH3E2BQ49MhqFNo6CiM2KpAMUboirBZbiFgSYUpx5b1DdUju6X",
+        "signature": "IOpdiP0EtHOCKZn+7ZlFTT7MiDQLeWzspeNchC4bGP6FtH/eqQT5eHBVQPg9/OLY58B7Z+Ir0CVMIaAfIRNOC40="
+    },
+    {
+        "address": "17n7Q4YhL5vKvaTkSNxiwegoaCuCXnZqht",
+        "wif": "L1ahxHckVaj39EThcPVfNHwKW2sVTziW9U6Q1dKkVaToqXTqXyrU",
+        "signature": "IJeNGUDdVLP0//+189da5cQd4I9VEwPD8hwOC3O2XzNfCkD1JrYw3pKXnQ6ScMak45+Yzt85FJzXqCxtwFCQ6y4="
+    },
+    {
+        "address": "15fZ9cGM9h3jYy6mCiYstbRAt2m9xdoi4N",
+        "wif": "KzgHq24oXvw9eh2qkyTnSCnG1t4hbJM7biF4kztFd3ZVoX3gDT7k",
+        "signature": "IKYLZrCU52KxZ5nSqdu2Y4aO4EDgcE12bAUFE6F7AY6oKuqvEYXr16/3GBX1uSltHpbkdfeuC8x6L+6hszQNYbU="
+    },
+    {
+        "address": "143uCjGTcFS7ZcqqvG5Qkp87KgHWp5dmb9",
+        "wif": "L23q8LughXAHZ19QrXPtyfgMHd3nnPqnobUCbZZRvCTCBnmUnf3B",
+        "signature": "IJG5j5kL24+GR70kAeiPuEOTA5bgS/5QStWr8d4eSJSwErdFV2/KhffLoCVX307Z7e49/5vfvU9wnOEvrHh75V4="
+    },
+    {
+        "address": "1EyqKMSMzSxxZfL8Xxh75apwtf9uE8ZPvY",
+        "wif": "L1EufMThGK16SEMVnU3xvendi3GgJbgiqJJ9my6dbhPrMo3CLyFA",
+        "signature": "IGR3J5EG4wfqvp6OfxpGgI+IW4vaOEk7jY//i//bkb/N2g0OtVQ1CzJMTpcWex4JJh+Sf1RR6fDdwr53oeU2Svk="
+    },
+    {
+        "address": "1HhnnRbF5HdP9qMCxYUXyZYiFmSyn9km2X",
+        "wif": "L4q9sERTjVXnwGc3jjKnuUzSdJC2DqJkKVkiM9NxcCZTb8vDQgk6",
+        "signature": "ILqgn2VpGEvuoAr9lMGZnUfbOUIqYyr+aDQF6sDSfKWdYGMjkw8xkdzv2+K3JH0sizwb7Wk9p/iT60RKxk2XYfk="
+    },
+    {
+        "address": "1GX3xLrSWcpi7DystcLhmsLLQw4UVbRM45",
+        "wif": "L2u1XzFbsYwP8zTHJr4CtAVtFXekR3GrnEduCqBSYqx2ZjY5he7L",
+        "signature": "H5zAuY4zyzWqGzMurQ8S6IuAOpo9klKI3qrWduku/DjBVxSZy292N5Vi41KlN3rPWiuWfcuK/W5PbWqE++xHjK8="
+    },
+    {
+        "address": "1AoXa1rqxGKtPCLm4uYwLoRB8Jno1yPHvK",
+        "wif": "L5bFGv4UYzyXoT5C8JH2dSt3439McApNH4mpc5yhhvCRZSZEwxDM",
+        "signature": "H9ucP/r3fiuADX5GMcrHbucsei3mg0pD1UZMJxxX6u/TxEkK5fSB+ZQpXRYch5Fj8d6FZIus2B8FRvb1WkzvMII="
+    },
+    {
+        "address": "14Nwure8VUK335BhdVPDaPsnbo4cqPNFsA",
+        "wif": "L2utcSqwskdaKHz6xTsvpNAgMVzUbKvtScwzepDrXok38wt1isGC",
+        "signature": "H349anynU/ZC+pclPK0WSZY22x/eVqHqD/6SAZKehDQVAn4gJ9b9LCJvBh71gmNiN43KXpUXlP3+3AkPC9rE0A4="
+    },
+    {
+        "address": "1Mcwkd9TMw1928J2f32eMFhZJdYNg3DJ1L",
+        "wif": "L249xHtXB1FTBQYcHk3jjcVHvcDiBUZeyRNYbHbSUHTQpCmE5T3c",
+        "signature": "H8GkSuH6ySFFiYdE3SH3yxCiooWUfzWBhDMS6Y6US/MYnF2Fq5JH36GSUDCR6DthzqVhA4IzmOFTRJLXoDVVgM8="
+    },
+    {
+        "address": "1313rtkE9YCrRPft6t1cEn7BQLqrGis98d",
+        "wif": "KyoFbyB8GdxwfVje91ozpwkBhtL6ZqFhEwpJByRk3hGqW3T13DxQ",
+        "signature": "IMo96LM7pLci5/FNJd3F8FxEAhaNQhr7xY40GJObdTikYvpWrAYYDVJOG8H7GelDCZ4J8TpkNEMwLC0R/Vb6KwU="
+    },
+    {
+        "address": "1AwDAXUxiQLAWXwS4fXCFWUKFCnnS12hkh",
+        "wif": "KyE9ZETbmgPwqiAWzWvpdPvhXjFQY2kmX78n2T6JGheXUNyrpALg",
+        "signature": "H1/lcb4P4/OtzN65XkDoQgB3IE+Il2o3R/Xrwcwq98Y3oIAD8jsx02NXUqyftO5fyqew0bmAb2Okx4JczwREzOM="
+    },
+    {
+        "address": "14P2YaD3ZR6uh6Z7FRfeis5k4M1Ju9KtKc",
+        "wif": "KzYQurK4HrzvKh7etMjpZeCGAheDmyxSZqZLwfgNgs79SUw2HhVH",
+        "signature": "ICvCrCGRoDg4dxNw1+BdKI7APNa57sRluimtKYI2i4LubQulIW4Q+wsQLr/qdIB3ODRPkvt5YBJl+IO2Xumqkrk="
+    },
+    {
+        "address": "12h4uaKw5avZMCSgZspNfMJQNw2BLZDC4d",
+        "wif": "KzLPw5tSweTeyipmMn9EumUSZqBvBBovokJNupou3FV1BZUBn1sW",
+        "signature": "IGkxiYqR6GLArABfy+H/vKVCXrD9Ipsnas1TM6qLKdlRBJD5MnRbBjQ8a34QEhtPJKOZhCtHEEl/3ZcRhF68Urc="
+    },
+    {
+        "address": "1EUTJBJ1hRk9zsy5Bjrbgdi6hCn8Vsymsv",
+        "wif": "L42pHLwDTxVoxdE5Wwfp14Za9v4kx9RXAXPwHriQtBcXRfrxwiEc",
+        "signature": "IIs7QwA4Kp+Vmk6Slm1gT5gM0Fp+Ud1gSBsq3PU6HKpFOxhdXI4r2ajc4whsF3DPqiZsW4cprt2TjG7qMGD6qsc="
+    },
+    {
+        "address": "1CkfqE817cy32ZCNUm61iihrS9GUeSKaW7",
+        "wif": "L5dq7x6uSmHG2JeRznCcDqj95qftQaDM1ZHSXB17iyGwJjLNY1yo",
+        "signature": "HyRQHFYjYfJf1xv2QFfDBih6Rr8QksMrnCgcuetinSiTVh0b2C+dbkt01hloFrDgxBgrH/HhIlnyBz2RIqi1OLo="
+    },
+    {
+        "address": "12eEcHXeXtmZ7GmP2entf3vVaibj1TLDCD",
+        "wif": "KzyziFNa2m2WC84NDBG2ix3rQXYcKHndvCjTkmJQWuoadpQxmdmu",
+        "signature": "IGPAhXmmtHpuZEf2b/WeKQy9mto+JEXSj9sTq96QyGaCkufnIKyVClnxuO6P+5339BqhdB6IPQUYaaHoJNgs/1s="
+    },
+    {
+        "address": "184baxHMv9dP8izfuziCCAHrgNsRrLzN5n",
+        "wif": "KwLDpsUW8LWsvLV1TbMkP6zfikWZ97qD8ef234mMe3ex1SXj4HcP",
+        "signature": "IEhwg+hTX1Y9o42O4PGENtq2ztGpuqhzOF0VErCRM5+jr7lNbwVzI8fEzVde7A/dCD5GuGkIz82jbEhW50GljrI="
+    },
+    {
+        "address": "1FWS3ujasK5oW4THiAoAtUKjaoyPJzTDco",
+        "wif": "L5irTrWG25mbMjRDvCnbiB22kGDqR8E3rUPg1xRZ3haVz35Q1fHp",
+        "signature": "H5UHyCchg+CuqeXc9URsvbSCI8ACeNl8Q4OQy8YKpd+rL5b99JBWyZfqjkxolT4UcDSfdYaKvY2yeyGtwF7rTkg="
+    },
+    {
+        "address": "159BYwD5mS9eTNGueE1Ag24GVbiAi92JVy",
+        "wif": "L4WNzfReeAgaEUAkyyrFxVJUB214QWzbKDd8hDXRUwNvPzZWoxVp",
+        "signature": "H9pjQfBIJm6FPlKxW65O0XYkGUUVCwWOa+4r8eHDTtc4YKpDy3qUKzpe2pHtRwhGtdd1s7kvjceS88uravZtW7A="
+    },
+    {
+        "address": "163c6wB5tvpigRTaHPcgnc7VkEVAVnPCcr",
+        "wif": "L1jsWBe8gRjWE6drMUbTZkiW4eRua6keuJm3AzouF11siedmtYph",
+        "signature": "IFI6skiJzxQ6EjzDnossNJBNnFmd1EsVwJ0fZw0RSGkMGTXFZE0+Ie5VVcYm8VTaX2lxkPK60JJMAJUs0XDfEcE="
+    },
+    {
+        "address": "17PBYqGHcUCshcwxUA74krGFxPSZVJGpwU",
+        "wif": "KzjUW1UuDSdnsD1RAi1rV2m532qvP9JEnj8NrXbK3nwwag2T4tVr",
+        "signature": "H7jU+nembbTdpfz48ZlCAyIcP6Akm4Kt1kvA9t7o6DIJ3FfkffCalSeiNlYqCWTzjg5nQQ17Y6lrMIJ7P4skW1c="
+    },
+    {
+        "address": "16XBxqa3kReetARy9zr4HxiiMEJxeE7SU2",
+        "wif": "KyFQR2j7EtJUPmucd19YJTidAAKFJve8f2Kpgpvc1S3FeFbT1dHs",
+        "signature": "IPOHN2BJ3/aTdpv9pUKh8PHzLc5N6yN56xKJUrrcJQMTbi6tEYeI+svC62P6X8pwKodBu5AVhjrGUlsqaNVjT3Q="
+    },
+    {
+        "address": "1Et2zPv51myLEijiicfEz5P8j2mS7JoaCw",
+        "wif": "L2pCvLoNSVzmZpHVQtrmAGtd1mKzUBYCb5e5Fpqfixs4eh2N4Qmt",
+        "signature": "IJeaE6Rg41PgxWTdNDcEvWFEYDjHoRRL6EI9m34kMiMSnJuKepGmyp2kRpPqLkoVUrXHpSe7nOh6WcKn72gEmQA="
+    },
+    {
+        "address": "1LdFKHGMzyeKk7tadZ5kTYdYDDHaHeiRzE",
+        "wif": "L5ivuZ77LMKmB6qeJTvdt1TSTE3HhfZHRiRGJCXXzK2UqxbqnPpV",
+        "signature": "IBT+f2JQKrxHx4azXFff6KbbtqIXQvoUBFjoIsnYYVkb2UOwykQtO8qGWrK9Io+d20l8XKzwahL7ZFZ+p5gQ+uE="
+    },
+    {
+        "address": "1Hp3WYiPNxRHyqgD2kuKrFsAJkpbbRFwCU",
+        "wif": "L4isKMvpjCt9DsUvhD8sRLQvAN6J8rn1hCPgLVRRGJtCRp532Jd2",
+        "signature": "H2vC2xsdEeStM0KRlc11OMpY5GrnV4ij5P9mc9tT5w/mJdEzJClyyDMaIVN7mzVobbRAd1K42ppmJ9esPl0UlOg="
+    },
+    {
+        "address": "1DXNaNXuT2QTsB82JFsDzV6RAHeckPsHJz",
+        "wif": "L5ZjyNcHyMxBRptBGqJ8J4NY7cwM7sCh2wSF83nEazXCqYcTep3Q",
+        "signature": "Hz5Z5Rw9xLHA6bxaQWbAi8zg2FsCCtVWWbGf3XKrsP5L36vMvGak7Bv+55XiPszlTirgC5U92o+Fgg1y5VIh95k="
+    },
+    {
+        "address": "1BxCxQfdb1H9nwjJPNoyBVgvNAX3aqH9eK",
+        "wif": "L3nPAoVpYpWPdDbGLQ57KhG6Jqrs73cUbqaY16bmgvAu5HfdKhvL",
+        "signature": "IFgCZY7Zzsm9kqL9Y3kHAEI6o7gV9gnEKr7MlB82b1dFPVErqo3WtWsz9EPrdIcGJ1sZyBR0hjXLo3aKsRC1ZD8="
+    },
+    {
+        "address": "1GXD1hfUCRQtN9RuZvovPG41sYZNh93ggN",
+        "wif": "L5nG3nroZqaDycChEfDM4WA6Wa7AYTbvacE2NQjZcNLX92GS9G7z",
+        "signature": "ICOx2DtydZcy/DnrYEanDy+l3tU4sDQVKZ+0LMtLqQtKRgHmxe+qrnnmOfsZsecV9bobpGn1j4GzBd7QgmoKpdY="
+    },
+    {
+        "address": "1Cvb9dMuP6zYgPz7f61d6YRUJBpc3vnmpW",
+        "wif": "L113EJ3bK172kW2bDtAP91SVk1DEstGzUU8Ve2WAg9LxWFfy8XCi",
+        "signature": "II93IbR8zfilNx+y4KgpX1pzSWzKCYLSdD268QviPcbY8LPVk6bDl881NhnOmsXaWMTWbn+GMEhUu/fLcxq0uV4="
+    },
+    {
+        "address": "145STseLAHiMx3n9Yr7rZV89DrCWJx3jEG",
+        "wif": "KzfR68GsosfhHRoQT3XNn4LPkKCbPLZCQEPYGboyTewQQhZEfAsD",
+        "signature": "IO9t6GLfom6RTi5f9b3wQm5h101mtivGq7w4n4sclJaTQNJ2FRTIRIjJmBs4LZLeffuXo1NXubIO3Kw3p3Oe8VA="
+    },
+    {
+        "address": "1FVSNHNwhgqVAwS358CFL4FBP9pQBqRufz",
+        "wif": "L4GfiNRNSjNiigqiFPsP2h5yPCzVwRjKzJj7AP9Wo8zQnXjT1GSi",
+        "signature": "HzWvXFMtCPcBvbRUTk8Ty8qWBPHSLvVX5MgygQT7jPlW1LkKTrpv9UkHIETdT7zcAZLS1AH/omT06GFxbc6eioM="
+    },
+    {
+        "address": "15QHUTRdCGNSEgRXtMsdMVGKgPfym5UgAG",
+        "wif": "KyLyfXnPXAvLJ1A1i4PijieKdK5DNBJJgnsoB6qVZpo3PAsVsi2G",
+        "signature": "IH2iUWTGKOcuZMcmCaGZHjwst+ThXXr89/4owiK+r5XxcxDLYJ9kGZURVdCrA4UzDlPW+QRLQPi0fVlh3vK0FBU="
+    },
+    {
+        "address": "1EEX6N6WbQHcsCw2fKa45g5K8QJrF44A83",
+        "wif": "L59oyiTmu6GBJat5uVbRX2cmbpV4yJbiqcNpRwS2hotH44o7agQb",
+        "signature": "IM9LibOO1APkZqXjgsnNILrW8kwm4GG4F+0bFWx3ZEYeemeVLlrDEZ8wqrX8Dj00AyXjYY9kWpS5BrU+jto+Vvo="
+    },
+    {
+        "address": "1M2yN1dLupuFNfDDzpQV6eK9WPg8WANwSF",
+        "wif": "Kze2QDc5rm3gNb1q7DSGGEUHi3qZUcTrEwdKFxCa6Pi6GCUmiubU",
+        "signature": "IDqiYmnJ8iXN57ZyUoSuCZn3mjM4IqfZUIk7QhhZ2PHES/wVeQg9emJmu664QF53slPsys5BfhkAxP2LEF63KVU="
+    },
+    {
+        "address": "1BDuM6EJH6HespbGLLobPf2ev25KKrCm2n",
+        "wif": "L1WTP2a6iarAKE7xRYwpDdXHkSybjfW6jdq5v1HUoZrCKMgrKJQc",
+        "signature": "HybG6Mi2IbTXKuTFhOdI42pm9b5kD9Tsp1C3TjBUXYzOSzr0Q0yOyr01JxUZs+p8ewjr7TQk6SbEvSfeAuuxtFs="
+    },
+    {
+        "address": "1GtXw5mybbsvxCGDtqoZTcjdDrbZBCfzT4",
+        "wif": "Kzx6BvqRZYYsKMzo5rbhLqaJo6SmR6E9e8T1yzRWhYaPHDS4jya3",
+        "signature": "IEJIWKNgYsgg/UkkRnmD5gD7Cb5jJdzuYDUZTuFT1nzillvogh71y7h2M7JEOfToD9G0bHH6nlfW7M6ZDUf+n6U="
+    },
+    {
+        "address": "169Df5CTDneqekNjjp1H9LVw1csW1UdUNB",
+        "wif": "L5kDLSkJSrVfMVG1dfYiuuhyBug1WoxEyV6YoFaaUza4tTiXizhP",
+        "signature": "II0i6EJOhIKrs75Q6shP/FCBYgQ8MEi/CwKuh3AYWvkkDF/I73wwVWMxgb7WZtZbRAUmQpEgGo5ba7gkIEUOk5g="
+    },
+    {
+        "address": "1LRffBFQuiJbekXpJgJESuB2v2fhdpG91w",
+        "wif": "Kwp5L1U8kNkevRfuJKq8DhNHdKdnhHExWoQFBBgAkcUk3ZhtcgPB",
+        "signature": "IN/7MNstRZKQn8ch30Cl3WYwn2oMawqjPN2iJucRcy1+IUt177EpnsBcmu6kcPvBVobaM3g04/A18lPWlAs9qEA="
+    },
+    {
+        "address": "15KamntmABnW4aWVo8kLbFz5ER78tN3VMB",
+        "wif": "L5WRW5V8gSMtwDnnwwVKh8mcUjtFHhzxdqkdUJZdhDzcAGVMeW4f",
+        "signature": "H/62OtZcztVO7rj7T+XB2nl84vBz514OU1iTF+T6BV9GFsn7VGbIAZ1bDjPmdDKlpqa3xi5MFI10UZMcaMQDl4c="
+    },
+    {
+        "address": "1JcABxW6TXRcgf5BZNV6u2xmw3pq8FNmUL",
+        "wif": "KxNLHVtoxU68ifG6gAriFh7ZSGqDxARMNNfYnffqocobaMM57mJB",
+        "signature": "IKjt4WcAd72DgFSvt9dEF62O1VZna+Z5/JFYTXuOp15ndzCz45qLz8Ph9DATZD44B593cKcjZ8fyIKNTkHzPZpU="
+    },
+    {
+        "address": "1GfZJwyAQ6MLfNYpUaU2ajxcMgQwZgdfnJ",
+        "wif": "Kz1akBFdrfEPaDhfqZnNyWD2n3csJmJ3FruDuMQAKyq1uFAknG7x",
+        "signature": "H1xEsIOvJAbPAGQ6NAd6Y92TsMdKUZc195F4M+t8V6TukZePlNPG4s6z09t21hNrVo7sUzADm10wa/u06FCTqEY="
+    },
+    {
+        "address": "18gTSRci5jCuV1qkhcrkXE6wQs3mVXsuJF",
+        "wif": "L4wT4erYbNMZHoCadDNcBevxmPTZwmrJTAtxfg9WJmfZzKn2d5YK",
+        "signature": "H3Jh4UH1s4jHHIzSd5U82cIMeRypIHCfhx5cal9ZzTqq2TYz2+y42Rl0trGEfRSargK3QXuR1GutspSspBP77QE="
+    },
+    {
+        "address": "18X5V3UBFEU7GyxTBVUDzC9zoKygjyjM5m",
+        "wif": "L1Ls4Bh31kD1wEHYk9uQNudbe74UiBsCv3oepz93KK3ix2iwWQzN",
+        "signature": "HxO5L4rMHfKhKiu2hYI5ICS8SH4Zvdf69TG+TrIHMOuP0OwRnn+Af1ARYQf3C4D8MRsqS2NIPt97JVsFHT0uYoQ="
+    },
+    {
+        "address": "1MH3aJKMpDitzmDeMpLRSY1rr6qJwgGhvX",
+        "wif": "L54jDho2TPS3m15Q3cGyC1JLB34374cJJQg9MQi4hix48S2SzMvi",
+        "signature": "H5l0T9ZZ5AENgJaR+OnGAlqYesiyRPV1lS3U9IhyQ6HlSRONfh2ctiVTrxMgAdIeVYk9wYeq+RREBpplqeJMDUs="
+    },
+    {
+        "address": "1AKGsp3mUrsHhQfMzaujRwYQBZxjknTmAm",
+        "wif": "L1GGWpu1wDDqL4Jk1nHvUiKGPfgqv3A4yZ6PPSEwqRdrHBtLnBVe",
+        "signature": "H9bb30fUNb5oWzK4cr6J6pJsB+foc1KKKaagigGU2qsB5BlJM0gz0T7E1c1/vpIz3cKHIj0ujYihDpzA0lQY+bA="
+    },
+    {
+        "address": "19CG3Q4YwszMaCACVHEreksKybNSD2LpnT",
+        "wif": "L1UfxnohDeahQXB6we23mCrBexuiGuwZcuBpF7NZcaZEAqCHgac5",
+        "signature": "IAz10RluG5W1uxRo4BAEoTSMVAAn4/7yeq6F9hd5zy9MIaESbixAl1dlA2kQeZzaCMPsQu1rfJ0hogXMWjTMiss="
+    },
+    {
+        "address": "18gyGD3527g7rMNs9FAq4XQEwGE364FuoX",
+        "wif": "L28wNvfaTxnzEhpMQTbDTfaPVz2nBK3mhsBPY16MoL7LeNXgTbcA",
+        "signature": "HxlQQlCdv9iRDLEagRcrWAZUZ2nt9thsKOaw5fGFok/nCF1VYVfsYVJL9Vjt+Dqtf30H7ZwTb9JBU+uV9kyZi50="
+    },
+    {
+        "address": "15WNkcRUMQGqqnniPz5QdCQU4ZkbP85wAM",
+        "wif": "Kzvo4Ro7WGJZecQ7yeRirPLFEJHSejsiku1Kvq7A6ntDjGqW62ZJ",
+        "signature": "IM7/m/eWUtMuwwyEcfY5CAsVgHEOPBsXLmfrV0KY1E1NMT88i6Ra4x3XLdUA3JLGRyWRXe1etOcW07WPaq/2RH4="
+    },
+    {
+        "address": "1Nk6kYcc5Jh3nUCEw15uEaTcuCLmTRmNDa",
+        "wif": "L1pHeQhsQvcH2zpQwPMTXhN7D9bNsdeWscWePqFf4vobcqF2HuEX",
+        "signature": "IA5boXMguIrwQZ62vzl1UX9UqVuu1CDwoOdY3z+lv9/5FQyMAyORL34xV6d4QOpDW6exYX1Z6SXJ4ouCzc5JI4s="
+    },
+    {
+        "address": "18gYZfkRwbvKmDVRGxdAXRfATDFz7PuA7B",
+        "wif": "KzreACkntbpsZfYfco58ZVnkeRD6eEq9ihYJxqqpZuUgPbtb5oaC",
+        "signature": "INIyfNlUs0D/vFj1twvoWt+xTIPLs1znWEq6TPcoV3EZSX1h/OUbyRAyhTe9cCrk/cxPVu1LBa2+Ow0JBOdxOyc="
+    },
+    {
+        "address": "14LZzTu9HZDQ8EboqU7LF5Kqzq76fneLTm",
+        "wif": "L5RHA8w5rHDFAzoPmvrMiuGja8ecMEdCHiYeHW65XaLjjCLaPvYQ",
+        "signature": "IE+sHMB+hWIszRFKJNYM31hTE5kZv6ZJkIYtSFbJytEIuR9ZgkRxyhoeyQSjpgkNiGfV7gJfoeYqnVYzbtBSIYQ="
+    },
+    {
+        "address": "1K7WUjovPrHiCV1YDYJ63TutnXc5dZRyZ1",
+        "wif": "L5PxEns2CpgcxxeV8Pu1kmDV2SV7JpL2kccZmgCMshNxhaVbPzK4",
+        "signature": "IE5PMjwHCOcUKtENdXnUO3rcvY560yJTN0mh71vO3uaMWXMShhpH9+LolU+bdQ7Iz9XKuRxs0IasZ9pFvZ7l3Os="
+    },
+    {
+        "address": "1LWDXFcJLMb7FS46oJFcaFoh6VLBg1E15V",
+        "wif": "L3qRc2CwHHzY1oL59KkyhzH6Y4SwW7xjZNuvTs1mLbZ5aKzi3UXw",
+        "signature": "ILrc48iQBhlpJsvkWFM1IrxEGp0emkb5DPIonkvG/I2QiN5zWlTlrr0b/Gos1IpeADDfoXZuwmSoH2oTQqeghAw="
+    },
+    {
+        "address": "17oLFjRCUe3p6vybT78zAWQANwquM76kme",
+        "wif": "KyfHJ63Eb55x7jzUfUZsqNCiV3j72JRCFiLqkvx7FWnKpnE3vugR",
+        "signature": "IAJ5a0O6BQWI773vRW6pARa5UD2qGTqYdFZNSpGzcDLbXIXjxiJPO+Tc9fF+0vxcsQBk+Mm3dV1Xc6MbjEpAGno="
+    },
+    {
+        "address": "15wJkbPmcukGD1r5FaH4SCtuNDbE3gTcXN",
+        "wif": "KxmMLGXged66XBdFVZmjAd7RKGeEu6tzsWzuqAxAtAnJmLfWw5E3",
+        "signature": "IEXoDNPk2ID2WuL6QPl+r7Sh6vLfpVsWGPqMLYgdRB+T++Y5eRphpWE08gf+GHeHpGwxZ35j35ygGINJuPfuxRA="
+    },
+    {
+        "address": "1FYRkiQWhNs46YgegM6XDvPfBqcYemGcR5",
+        "wif": "KzLwj9V6QXfVoKFnJAvcs1ywmxR5DPUc41wRtEk3Uoz9siPbG4S9",
+        "signature": "H+8cEdCRCaWyvdWrAvlGgxtVi9ITE8hq7tMMMOeo3+MzhdGiaODCYYN93QbyCUZCPKbWhZwFAut3E+zwfUm74Qs="
+    },
+    {
+        "address": "1FykjChZM7CXo5qgcSzhi9EwsfzCGLHJ9r",
+        "wif": "L3vSTuYt9WkcpFBeYcJKPYtKUZaBSJcjGKU6u1piMkVCZMHXy9Mx",
+        "signature": "IM8Mfu6VeCFcva4xbTd05Tw1Fz/x7ZE9jUhZxwhjZlZLi8FllBexBZUYILnfVWwcnIb60jbMrmYXZeieKj6eTjw="
+    },
+    {
+        "address": "18ryNP9Y6sj1mM1ao8VJHAnnVE6aMN9BZj",
+        "wif": "Kwh4pCJh5s8pnccGz775q8vxyXMgTh4VRhfMiSy4j14o5aQMdcxS",
+        "signature": "IHksgi1przvnIEi20+1FU1EGJJTE2A0qsxgjhZssDi1akIQxlIgzcHG5a6kumOYCLh2pgnc6SSmKR0fn3BQTsRI="
+    },
+    {
+        "address": "14b5i7LT88TVLa8Xc15fZ3jTsr28v7TiaW",
+        "wif": "L2bSUYqCxuB1hktostcCmUz5FQPu5Gp7sKPEnDNhQ29kQWk1Q7og",
+        "signature": "Hyp6mq3VlP3DSQERz084eYwU7uycGy9yG7maS15apk6TJ9nD3MsAzqwnC7DXrAUywWqkgPPVcpd6wRB5E4xPzGc="
+    },
+    {
+        "address": "1AM8daWg9Yo7QQsqhn8pTM8aqzYJzEfv3b",
+        "wif": "L4PbYoyd8u3aRXyJLsha6Vu5Lm8DT6W3ecqQVgqJzYyco6B8HCiv",
+        "signature": "ILm+EsrjaLQXcz+TssF76ucykZeZysUQ3Ycl4c/Yia75ZrCTl+Mf1RqIS6pypMmzguobC2ZvDLWn9YFVORajc0M="
+    },
+    {
+        "address": "15Z5e3wPA6pPFBjtZDv63Rrvnpjfumwfcb",
+        "wif": "KyxE7fP7DhpMn2MKEL5MgNAAceUfRg6HsGdYSNJcdjVaHfAw6CXo",
+        "signature": "IMIXhUwnhG86Y03Ijt8VZ6MEtnt9UXJIHvRL2PWssBJI75xpypG1GcfHoSDKFfN44eAqoJ0qvoF+IOXfq3cNdxg="
+    },
+    {
+        "address": "19QVaXZURXyS8u4akAcVvSskyTYNwdMNQv",
+        "wif": "L5APBPo7aNbg92citzXBaHEjrkHNVRKhcVRHF3iZZzCA6XDSNtEF",
+        "signature": "H3j1BjzgW928ObBey2vSg2WF5USGXC/at3X2wlmim1/QTLqI6lQExoqMidiQ1yC0CVl52ywod7FSi3MHAeV0CGo="
+    },
+    {
+        "address": "1KXFFRd8jenZwikVsH3waxTcBqvnnWHYSG",
+        "wif": "L4fy5cT31uAavPSxvrtFvMEEHRw64w4Lv1HwC6871dh8ZTVFr7w3",
+        "signature": "Hxu2odpNOycOIDeVxBgvGg7Z34ASkKYY91Ro0gHwX8LuKG2VRN2DYFcL0i/bwrcXd7ohHTC6/HQM94HZXfYv7v0="
+    },
+    {
+        "address": "17dyke1cznQZbo9FFTiJTcF5EC9UDYfHa9",
+        "wif": "Kxtdxymf3TYjJbnYNwiLBudCBbRr1tgFF5tZFUB2bEpnQLtjNtCo",
+        "signature": "IArkfHdNFnkwLIPabpPak96mNyjWW16v1rAHJv1x8If8avXsz7XP2y4bUiMEm1ubMsISm43mRzgMv5ZpYrsPFRg="
+    },
+    {
+        "address": "18zbhF9vCuXdCo6aUVgrkCdHmUriKhRRb2",
+        "wif": "L3aUQkcjEVgG3sqsL38uHBS7ryRTRuXktUAnkqU333C6rzbtDjw9",
+        "signature": "IPXpultX/xpsIRLbyjpBQ39ifMDk281+PkM9wDj6qHMhSoU4fqozelHPHvYPdqIgDKKA6QE74oy+KzJRTWN6dYw="
+    },
+    {
+        "address": "197U8iN2qxkRKZs6ouAD1eUiS9zxPb9sAW",
+        "wif": "KxwYk3eAZD7L2WomPafxe73FbpDMiAokE2DcWi9B4TiUeNjT85np",
+        "signature": "H3dUUpC91mx2t6OOUlfl2qcaVx5nZWbf5VKck3YZV3R43GpTgLlYLgBr5lVm2pJK3GXSce0IILPGxbuIQp6u5l4="
+    },
+    {
+        "address": "12enMBzw5rNAnvqhgZCgF2GciVMT5uhaBg",
+        "wif": "KxBsZexBjcC66fYGdr9M5fmUWjyUNBXRDRuCpt64jnwzNPMmGPiF",
+        "signature": "H5IkkOaTUHkGVbxQ5bwUgcuohKKzoU0hJVBuiGYk/bIJ/rYKzgMjxIVDXuGxTaUg3SEoThv7yH0vq76ZnrISVgY="
+    },
+    {
+        "address": "1AsydSHMj14oKps7hTnwjyM12gCKL3PcH4",
+        "wif": "L5hHKFm3Jmwiih4XFtRE3nXST92JaY82irdztrEn5NWm6HytcfjY",
+        "signature": "H09V/Tfkgg7ToNQEoM5TWFRheAKPsA5eBxAgfmMLpeE1pzXWVwfqAQ8vNREN8MYv43YPy17jNdstbiOUQwFRGy8="
+    },
+    {
+        "address": "1CMqXad7rHZNucU5x3DPHjCxX7F3F6XtZF",
+        "wif": "L1R93kS3DoxQMvcRMDBjUYgnRA9XTeLGUEvP5xhc55VfxsP5zQfS",
+        "signature": "HztpK83pdtiu0CNf8mhzxUFfFPKOBcsqWLRZygHWaDxLtFewYMxI2yG7NZgzlJ7pKAcD0JDJ3RufDR6VeZxwkN8="
+    },
+    {
+        "address": "154ArLdUuCdtWef4d26HEuAqCWmMDDUfLh",
+        "wif": "KxF9CpKkm4U48LBRegV8oXR7M2sZHNArnr7gjotgjJhUeQRp46se",
+        "signature": "ILExo1wGDChNrLMEoELq7i4HzMEjGH52klKTIjEL6eC8IEcry1XYoKX3adOT0qYNWy8viJSOi2CjJKYqZAWzDFE="
+    },
+    {
+        "address": "13cfNWYKWW65fT69WhgtNeRJypxcuE9VyF",
+        "wif": "KzLn6YB3AdgNSrySfT6qWvn82GVFqy91CssiaeGvZ7GjEzpComau",
+        "signature": "ICDFc+8R8Bnljs9TSsmr1qzTbm431AkRUenZ5kf/hnGiAN3mgq7E5BiAyE67r6thT1qDSMf41xujvtznLW9ZdTs="
+    },
+    {
+        "address": "1Yi45LzwCSGvaDKfYZKYw1YJLgz8R1LLJ",
+        "wif": "L2fS5SMGqM7yVTbhCRm3LwbuzZMkWVQnExHPXzVmd5szzbKySmsd",
+        "signature": "H9b/nH/ohTTW/qcG8Y3lRaRf8JdtEN2uOcswWqssyDK1pMWH6SxLTZcQYwWiMzbqebFzIaaM1dDTcBcP1ca/eGY="
+    },
+    {
+        "address": "1JK3nvbnTBiV4Xsf9WLgHrwe1Fk4ZPvxLw",
+        "wif": "L2PrBqtdGcvQoudokcHP5STP9qQBmSYHpz23pyak7xAzPzzS3i26",
+        "signature": "HwgGpTDMVS56ah/DgXri67vrBrAl211+sVIHkziP2Pj8c1KBEeukRttTkwH65HnVmLC7wF2sPnHpyV/6TOnsnVw="
+    },
+    {
+        "address": "136V7pa6xJTwe3ZjxLTwcYXCjibvVPJfem",
+        "wif": "L11aCz6eeEChnAnVGLEGghjWFf1LvGZdhRNMckBcy9P4znSPCpmm",
+        "signature": "IEEtM743yIerINdN6jktzb6FLbFLlABW/LSWP0PZyLASoFbKZqZelOr/SlM/Yg6WJyzTpkH0PK8fZ9xM4/TpoQY="
+    },
+    {
+        "address": "1Le2rCqhgXRMJnWCBE7rBHdZ8kq6BsJ4aJ",
+        "wif": "L4SJCt8TyBrXutYprHVLTTLMJEoRwRyPxPqP49Dd5F5kP5m2K1zY",
+        "signature": "Hx9eWJSJfibOjV3GF5+WmI64T7G/VMjZqqd86qQ4ZU+Ky+wuFyw0DOwoxup+3+sp3wmNvgM1WbPu1rymN3YD1O4="
+    },
+    {
+        "address": "1MtCnAy9pMeF2bnoZgxMw2bf3gjW9JZL6T",
+        "wif": "Kz5n3JqP7gcEXNyTyYGdEFcqMvmNEKRFAJtXh2EkvqAeZ4Pgf7po",
+        "signature": "IBJCJZa6tsgbCvlVoQh8K6JkdP804rqs4tmZ5RUmxoalEjEYOd+AE2ClEap6lcF9Ej3R3cVcvscMTFqI3Dicbdw="
+    },
+    {
+        "address": "1FiDyN7y88jxpanEna6BbjzEyUHgjL1UVr",
+        "wif": "L323hwwEN6FfsJd9a3szoPaPNQV8uxJdMPqdvXv8hapJJeiRrgms",
+        "signature": "IJ5052PUxE+7kSabgaKyG6VPlSSAS/IXlb55OmnVvBaglkVnmcADG8mWKpoPftCEOdJkxGrPMyhFsQET5jyTckE="
+    },
+    {
+        "address": "18pT7zb9QgpcZoLAFBBpbBkJqe3BZY5hhk",
+        "wif": "L4n5iVXA62GBg76wcDCAojtKLf6WyEbZxqo8zqFvGENHQizMhdej",
+        "signature": "IGlDmbTF34a+XCct0K681DOl0NfzuyLJDfLoAVTDhSvpIqVz08cMRJcyuRZiXfJfOjGGpgzTgXZZJL6YsxC/1Mg="
+    },
+    {
+        "address": "142ZivDuV7mGWCiUpwdQ2z13L24tMKidq4",
+        "wif": "L1cu5rD1iAZmcAcgK87o9jF71huojDTytNVLYFQ1Fact8EK5B7GB",
+        "signature": "H6uxflO+kXQkvfw+vzrEAubB/W32b7+6qNMQCwLLNh5pppt4EW0NHUClvBJ8UNfO3ZGS48V2NOu7a9wcDGgcBPU="
+    },
+    {
+        "address": "1BtCK1CiFyby9JVX6wJUqoN5nAuyNsaAkE",
+        "wif": "L3fL6nKqvtqgbYwpquRnHNuqqVGWi2DxL5vNXFzfuMKDBE86mPSh",
+        "signature": "H8a6eRXEY4z643GeLsknfULPFUR40/7VgSp0FBYrWrNTx9qvXsQEfaYkG8dGdBUWmNEe9kL0Au9owH1XhREvwY0="
+    },
+    {
+        "address": "1JhTugoaUiSk6a3UvBfs6DH5RkLr9uLbBR",
+        "wif": "KwRxbCHkp7U6yDj8Nzm6mfiYaRfQxi6gAwkDWpsu79sCbJcA6xxd",
+        "signature": "H7z0nHp0DHZUtU/yy8e+UUsEN6XYxZTRVcWvi5meQ9oEyWYpYgDYC95FSNOKZAkCfuNrDY3OV6gMIXGn/esJ1SM="
+    },
+    {
+        "address": "1JwwdHUvLsfsyVUoskfkBTvyYqLtncXLwY",
+        "wif": "L1XqH456GCKsRPrgnd18wPQVs3WVcuxNGBmmEdRHFdcaM3MJKg22",
+        "signature": "H5Q1Ztqtev6s3uCYROvPvpaYJtfKysa5FpGxAN1X7vswJpwFMxgIfzALOKcx5wLqNVDMz1tfDbnHWMGG2k1ETVU="
+    },
+    {
+        "address": "13hd26fp8TzEXJNeUBNdcfnfvXQFGAAhTA",
+        "wif": "L4JgXdcdS7v4Rmw7YAe8Sxig4FFSic3HVN4atG7H7ArAMmjqLRHX",
+        "signature": "IG9AzsGcCEepGaPc2Qe2MP/2flR1ah7ncP6zbX9c6uwE540zNn7X1oFfHGQZFpOtERkgENYSfrWY/Wq5iqRQYZY="
+    },
+    {
+        "address": "16ucY3uGJi1pptFzKph9nsQzX9L1Zah7qx",
+        "wif": "KwMgjkwwWwDeG6cDXsmaQCkVM2pSZzXnHwMxrH4w1oniQsuaPSnb",
+        "signature": "H0m05aWt0CCCNWooc3CGxYyjxw5ziao3Gp0FxYRMkE3x9PY5XHlCuUVWzEy1jLfGSiyaCyp90b7Z0oFQuQ1PxT8="
+    },
+    {
+        "address": "1FLGMUND7pQKV6FbLZ7GLChPpHjYuzesw",
+        "wif": "L4SQQFAqjaoHmzxWnzzDm83uRhLywVGAogTjJqu1CfHRpFoNRGtp",
+        "signature": "HyAcsA60GqRTdXu3cG5+u9Xo1gjhwPkAIY9R8dX7sTN4wfrSbeDITnPQWMGd1CHC1n4N/TYygsm91HtpF71F6Cs="
+    },
+    {
+        "address": "114frswQGaefdfq9ZY9gT5N31gLX3MWjGo",
+        "wif": "Kwsmpz9fE1zQqZM7ieypBLz6dRizLQMzzyELZV8Jk24MbJT19N8k",
+        "signature": "IJzFqaDw91unjuwMxG0xumDbsceBJFg2b9/aryxg/CeluydKkJDZhlsd2lcyPKCLSth9utwlkmTlN10Q5sYtbDo="
+    },
+    {
+        "address": "12nNtkmjgHQmq4yKgtbNsgBnqGfUXBym6f",
+        "wif": "KycA7FhTrG84uikZ1o1pNV11rhSSAQM623thGeVH5pfXDMPMHSZu",
+        "signature": "IBe6FAwyq5gGh9E0DRGddzqW6uiqP4bOzgsrp4aM4oGccboaLED1EtQ4BxiVbj0CsHTkAJxvSvH4itMIb1LJc0E="
+    },
+    {
+        "address": "18zYwELNgkkFo8BH1Bssq6BabtKCHGUWHa",
+        "wif": "L5fWXwd7Rw7E4yf7f4WtiSQmgqq6HbtnHqdUDsWf1s82W2Hfd5fa",
+        "signature": "H8ESgZRxOis7+etBcEqQ2Tqb+41ymg4DuEoTIB6IeyVDOcjdjcLBfoXSviVVVcpowGsyGnUVg03HpF7pwV25Ih0="
+    },
+    {
+        "address": "1PcuefFpE4JPA98t5mFuk9666rdq56iyFQ",
+        "wif": "Kz34CMzUxYnXzJzCcPWF4Ta4ckF77wZ1YEcwu42b3PhUiqqjFxQJ",
+        "signature": "IF3xL4OiZmoMe7faKDGpKXBfoAi6B3fn9NnZ6hH25iNfvcmxaeYyiD12qsYtObGHgsgU48+EusKHQig2e/s988o="
+    },
+    {
+        "address": "1HNHDnzL5ivHYH32Zno7Ve6LUuN8BrUcsr",
+        "wif": "L58PShsyAj785EwXbXbpNUwnF6Vtf2XVXXkuDWamCVGgUYgXZicU",
+        "signature": "HwwD+jHPTm9Xk0M3LYja9NF5b/6HFIxFXIdjI4H4tbjfvwg5NVA4W3TEhGCnV8H3Np3ZfHLox0Z5kf7B2/4YCEE="
+    },
+    {
+        "address": "16vw5dMgCHA9ykJLg66Csjgj6d3GUAQcXN",
+        "wif": "KxJUYAxARCKvCmhxoT2x69DKqJmNw2raz6LHhqUXyXDKGEaj3Na7",
+        "signature": "H3FE5gcyjPXC2zBWsOQzZ1/gen3fmlqkhu4OOSajmT8GUQQsguaDAp7rub2EqNvBoJ9WbS/zG98eM85SEJRTiLs="
+    },
+    {
+        "address": "1CxxVdX5vFjjm4j7HFdNs95bjHfqYfw2km",
+        "wif": "KxQkTAQFSZoLb8YMruhTM86dRkLn3ULV5wZUr4aXg1raEE8xmtr2",
+        "signature": "HxL1S3suJvp9/mwbAtUgfWPenavgWlJ/0mr7sHPFpMQaaofMIX8i/2GWgACdg6ydw8QEI6DvSGIjKsAYQFnN56E="
+    },
+    {
+        "address": "1F6RLtVepf1YmBJ12XLtc2ZPjis6MujFV5",
+        "wif": "KwrjSVqzdQkAdRpJStoRe8v7rBdjqVTmP2WN5gUTuyqA1K5nWoHa",
+        "signature": "H1p7S1Sh0+osdbBNMRfgqqU4JcvNe0eO9b0k0QzBp4zmLnkwKSf167+nxdVHaB5Vm4YOz0k9UappNnjibBlf/kI="
+    },
+    {
+        "address": "18EN4qWBkc2oui5aSxg7AVG1nTakH2xvJ8",
+        "wif": "Kx5JQKczGQ4kvkwzjQgMDpsGGmovPqTdnKC7HfMEzKBBLsA38SJ3",
+        "signature": "HwJblWRzZh1C91C3PKsCKG1rer+pk/mQw7/0uT0HGHY7XjfymI7t7gRbU/2imq60wf/oDxIqs6rZVO0C/K9gbEg="
+    },
+    {
+        "address": "1PL9j8JE9NTAAu9Em5dKJQ7Xngf5B1BKZH",
+        "wif": "Kyne8Y5kRHBVbrG5WskGBHcSUJscDxACbT6oL4Cw1HvjtiZaBzbi",
+        "signature": "IE/9pf6kC3ayQ054+aD8kJiuXTTN1s0ql4j12wA3RxEyKDbltLHvLH0V98DNmvjTdzmLqBLG5GAkdBwYVIhHeBQ="
+    },
+    {
+        "address": "1JB7EWy4VstHUYYShso2hFQemB1c1s8WXk",
+        "wif": "KwRW9DHRE4ccYAnoKV16WXgeceyVohk5u6LPwYoFzoEudS1sKBFk",
+        "signature": "H7cdWu9GGqkujGwPFMjFvfzUdGWVWVMyCfxaerENqv+NQ5YkBY9PExR3C3lCzx+gf1j8Pbg5E/sdfowubMMxhL0="
+    },
+    {
+        "address": "1LUjN5oWUtWDYLV5CkF8h4jTtsab8QqwjQ",
+        "wif": "L1Z9cVF2SwTcMjh9tv6pbtq9RKGvuvw5fpd87Q4RTks1RLSwefRh",
+        "signature": "H8mqfJc+FZehDAga90hPH0VfIvfHi9PwvJIj2C0K8bWy+t7ASmy45bbouLsfgt8X3m32l04WfXK4reSeHEi4x3E="
+    },
+    {
+        "address": "1Nf8eRSRgkp2RL1Pfnr4fnpxMRrjSPRGhR",
+        "wif": "KyT3az4Pq7NJS3KSq58DRPp9CpFXnsMEan1wQeFB6tmvYzCSunYE",
+        "signature": "IBULc7dfaRlAlg9ogbWH7l6W5DXQWbtCZhgJ17RKmj5v+a3Z2fvMMGcDHJv2uaSSowJXrnYIEgMd6LtqNFaHh2w="
+    },
+    {
+        "address": "1BGN1Vfd8XfTFp2gkgHwaSvypu8N3UGxPz",
+        "wif": "Kyzxe4zYuFaUPzcft3aa9qAR4zdZCMmUVPBwP9TupTTVADfmsAx5",
+        "signature": "IOUnxp6MOSdjATJh50SVfMEIZz9uCi9o45P3cNTQB66taaJIRmr5LSlID+xR/TSJQhQfAqbxytKGwO+sZYOMjgA="
+    },
+    {
+        "address": "182sS9BeAgSyx6WNDJidthdtfmu3CxHp3g",
+        "wif": "KxacNvHwdjWF3FTbuDb9s1reUrvhdpYHYTHw741jQeuKRKYBQVmi",
+        "signature": "IDF+wb6KSMKaquxqziDk1l3pxQEweSy/0wkhuPuvnFFXZGvUW6d+Yc+LDrF2IzKam7RA2868k9vgReLrb7oN5Fk="
+    },
+    {
+        "address": "1CgftGrr6zd3JKLGLZqjg9XkwUQos9TzKh",
+        "wif": "L1KsN27ic9GxsWS8q1wqvhS5p2stifxhcibXgJGfQsoxdmutvc2E",
+        "signature": "INM62jukmMO2aAYMPIdd+ZX1wuVpxzYfTiuWI59t4X4AHqD7uekp8pxVjBe9gJkicxUiTjvnFkchEXimnIUJrMM="
+    },
+    {
+        "address": "1LTA4MuaQfSrxSoqKsSZWnzNqYeapsBFMy",
+        "wif": "L2JoR6K3gSUu3ZTjVsMZSGuqRhz5bwN55PdfkDAWXUikwEJVjAg7",
+        "signature": "H2xHxz3Otat2odzjmWMZ+Prksrjb3SRp3m2b1CEvXVi1XpZOeL8cwU3yFLSoC0kLMCTy1Z5Rh7SfIysxFWZjcxc="
+    },
+    {
+        "address": "1PRtA7hCYzrFjuYTymsx95LTp32zM2P3pg",
+        "wif": "KxHRZ1QWzWTj5tGkCpiwvmmnqLwwuzTnWsyhacpsRM53hn92kqf8",
+        "signature": "H6eqmm1HKhyMR+gZgPzWlpRXg2QPNgXB3Zge5monKaDIYLqIFno6JcHbGPQlPrcY1LeIIfNWP3DVgprQovQ2i1o="
+    },
+    {
+        "address": "12JcGBZza4Vrdn3mGyv7WoxMHqkTQYRLs9",
+        "wif": "L5JosQVcAP5Q7ApyGq839eDUpYvAoDppHn5sXFbZkjhWKjsD9BaJ",
+        "signature": "H+d9w64at/B26WPzoQCtOuFxYKxWRijrEqxne9broAiXj8cHXgdYUmCfdEeTcdH2wuxti901hUpu5zfyZVBpZoo="
+    },
+    {
+        "address": "15xVtXWQSmiDF1FVbMq9mTBrySLrWJLDdB",
+        "wif": "L4wNfTzzaFjMwfkFemTAwmZgDESVf8f2QTfMmvojBzn4eoqEhsmR",
+        "signature": "Hxs3TMFAV1XeibZyI/Rq5X6ejbozU8e+cZDZ39FCKA1KN92AFvtkUxSbqUWqLKAnkfBiz8bDyLl531amqMHiN8M="
+    },
+    {
+        "address": "14w13xbzCdCvrYLrGWdi6ExWP3jSLB3Pqb",
+        "wif": "KyJyrAr5ugMeTEntTNBDyPwLbo2YvQVBrHtKv7nPYPK8XKSRZg6a",
+        "signature": "HwfQg1x1PfBYxkPutK+CDqPPtWEQrHaEjuoNB0R14SgnX9RYcvZIHl5cz8KYiWRh6lwvTmxAf+FPL0/2jiE0kUY="
+    },
+    {
+        "address": "1F2xJ9izn5AbXmVQjqPfEnrTT5AFDa8xFB",
+        "wif": "KxKxt7ntTDhLLy5xhuAS5YAxksSp5ceP7q2pvruxL5vdZzmoRHKG",
+        "signature": "IL42d1xHf8R7PF2cJ1+BcOyjYzZNWovR5lVegBF1vT8wHMj2FCCw+OmywxN58BijpR2LDQsKsHkED/8QwdAaY1k="
+    },
+    {
+        "address": "195BmjZJuz6Kc9vj6Sn3Ujw8F2amAVu1YW",
+        "wif": "L21X7Po1DuB49AhBiTFFQuVywaBRgwxKKdwZv5vRnGKX26wtKg41",
+        "signature": "H0+ZEL/kQ1AA9ha9Zgkk6mPmGQCqDPPBiaU/aMEmfz4gNDODDwAuDxQVBwoFIkp5QJ1l0NWuOBbTVEndaSOrFig="
+    },
+    {
+        "address": "1Kp4n2Z3RacDrwAF8m7ZhFYBjVzSP5EG3v",
+        "wif": "Kyqk7GgVWaaJSa681qmNPdY2j7VqhcJ9aUqBWCrF8FLTbyq5A97z",
+        "signature": "IEcl8PyC89VOmo33PiDPhUQnDxWzg336QHu3sZ54IrA9KNy0l8iaavWiMt/o6aK1ednn1FZw9NL66PVAyxSZyDQ="
+    },
+    {
+        "address": "1Ahzue8Ksu46zDuHehN4tkNx9pnrFSV8Pb",
+        "wif": "KxYddEN95vRt5KMDXSzX3p7m4E3KL9aBPaSNAZSRQVQeSWizHEtC",
+        "signature": "HxzXsWW12bhsLbiBIH2//dgRcRt4Cu8kMEl7VxTeqhNDXa2koK2OhSID3InxTHz5q5y9av/rT78SoxRfItWx2Tc="
+    },
+    {
+        "address": "1K6g2t6q3SrMQTuvxMgm4arYnye9JUokcb",
+        "wif": "KxoJLiGXjMjYkzV7z3uAVNnk3firKe9TU87RwSYohfBmy4qkd6ph",
+        "signature": "ICocj16ksUcsbynjRhQkxKY8AfLJBYS8VvsU+qi9UBBtEdXN1gpivxaWVJcPdzZDC7rkBeq3rPUi6wD3jf8GbMQ="
+    },
+    {
+        "address": "14H7VmFPdvh9otGRSR63X16cTd8KNfQcsJ",
+        "wif": "KxUQdjc3fPtgpdFsFsqGveFY8UBeP6GUazoMni1cc3xM2tnKEwjP",
+        "signature": "HyAxKcRNpe12D4rjnYQM+9r+mxgkXblhUUhQs6PsC+ILvMjLnWN5V+atoS2TjrPwTLMfoToGKDpFuUTKYBE+T60="
+    },
+    {
+        "address": "1PKmkgxUVjhHwmFH9ZXw29ovJLDiMgS85p",
+        "wif": "L5KLavtpkgAeCHpyuaXBDdoRrCojy2vnTPHofNizTFH2HzjPgtkd",
+        "signature": "IAop7pO82as4PrGY+d7237Wh64Br4m4H14SdQGwYb0h611IFD3lmYQVLtl8ifhRC/FJRn1G4q5Sbw3021WOpx9U="
+    },
+    {
+        "address": "1GkAeYoh81w1XUB5QAjewXcLJuG4MEPMGg",
+        "wif": "KzZkyaQ2p8ycxZkAV8t4VhvVY393H5qtWm2JwFLnPKVqzBc8aFqF",
+        "signature": "IIDb7RGOiwORafjsU2oeTLcbfMzDs4JHgFWnj3asu4zAmqS5xJxgBrQ1dPDMtIQ9MOf0goUkMdN1yho04TUkCCI="
+    },
+    {
+        "address": "1AEDebJoNN1oAWFWxQBRDTV3Q9JY5zF7qo",
+        "wif": "L14Y6GTQXFAGFgzdWic8GG6PAdJgZbKu4YZGJBHndn9CPFLpUuZZ",
+        "signature": "HxebtQFHXBZydScE4/gUA0jsGDKklLSwxKK/jsWyVTQw8VfiD0lJEEnTaSv9bgPllNbMEAJXvVtU23kfb4W7+L8="
+    },
+    {
+        "address": "1LGQMUrgQQjdzKaNZW4VRsiWnnzGoWZTVW",
+        "wif": "L1bYMTmFVu8FFoqJjqHQecy7h1cgdcGvPwFBMeC2fitFxEvAtvLR",
+        "signature": "H57ky6Qlfl+Jupof4pxSmsypKniiDA2otOAP4tsIfYJT3K9GxjmFzqRtaT/HM0sx1xESV66kL5MPyFyHSf6rsYM="
+    },
+    {
+        "address": "1HWzchVECQUGJKhu4Vx4z7kX9WwMvMoZGh",
+        "wif": "KwYZMN1CTCpfJ28xvAPWQLrWpu7FShdNhhFt7Sc87tTMTepMBXFK",
+        "signature": "HwyJtAWLpAFqMEM5FjC1tncGKP7I63QtTsOPbedsiX6Tg+TiDCdYVBw/3V8vwqWaH3NEhm3F3haPHgf7dfIjcZ8="
+    },
+    {
+        "address": "1NT9xTsRc5mZPnRRzoHUsGEBRR9EuB5VSk",
+        "wif": "L1DfXwwHAHiGQ9ziXB5DX89GSTNS6oGYsEKHNWJjrFnvjza1iBpq",
+        "signature": "H+wfYf/vA50p7M5kpreHBcAj86W1qgdce7cxlrAAolYYOHrdmR3MHVFddTs41uLPcZQCkiSmbxcC6ETeZMxykXM="
+    },
+    {
+        "address": "1A14Zia37FtzscnHVQMowHZzcoibUL73wc",
+        "wif": "KxjyEjdQ731DUEqQVYhWpmkbBKJCY3hd8pKwem3RjGJBygeLQbLo",
+        "signature": "IJGTlHhcyc1PwLnzKg8lwAffGMJzcAVwYMyIiJ41t2gLOGpBPQ9vr5/j4KncIedyKfFi5it8JBYUu8NzUtzfXkQ="
+    },
+    {
+        "address": "1CXVsX1dRmWm3KedDtoDMJSbenfdeDPK88",
+        "wif": "L4oLj8ycPZsnsmK818Q8cehakD2HXMwysAUBmWX1mVErrpfcwZ5G",
+        "signature": "IBTHdNmH/L3dsaGEQ2BD50HJj861dUN2oXNV/MDc4x5fYwfDQ/Hc1ir8XF4zg9bRIyoPLJL+qKcfC90tyJbgwcY="
+    },
+    {
+        "address": "1BMZUpFe3FZj8n3XR94FXhkxGmf9KRYKGg",
+        "wif": "L3hQX3abPQWia9kosanvrK6btJkm6Dg2Qcg4yw9y92BjJCJgZnjS",
+        "signature": "IMisx/Mu/z/Qeo6ZvT4zV+NysQmdBd5L/O2Qm2Kb4re40564PIc2asiXtN63+H8J9ih1XsN8eFn5DzEkb9D8kAk="
+    },
+    {
+        "address": "1KjSicpQLoEzgqg7SjQnNFjNkQdKoVRKVp",
+        "wif": "L1u6YL6vugnX8zn22pthNr63MLaCNn8rU3ex6UBV6XYtoEGmoeMu",
+        "signature": "H1UP0Sxr5mKjT75dJGo8E4n2hB/SYrWb2ttSGsOgHPiDky/UxHDrpYFLVm5oNDideGLFUOdG5yN4oUvIoVcryEo="
+    },
+    {
+        "address": "1NAhHfAR3WGdaeWg3ZXhr8sAtUGPFJtKTe",
+        "wif": "KwZr1A9MtMpvdP7iSoT4AyW5aUJiya4toFWePt4ijnQrm5A6xbye",
+        "signature": "HxSqKGPg1iUeMKrBg2GYz7+gv8AWxirPo0eLHLThUTrL+bXgE91dcgdy9LPFOn5wuvIRxSp/MsRm9loYa411osA="
+    },
+    {
+        "address": "1J55LFmr2wwXwaLMAxidjDAZXUHMgS8nL5",
+        "wif": "KzdNhSobjBTUEpQstbGvCZSVDjxJfnCEHycfuLWHHJ6CSNeYgHax",
+        "signature": "H2TWrz6xO7RGdoi2qgqrcr6PLpVbPyr/2sN3F/0nCE0FVE/sBcZGQJjRVpsp1EYx/6w3GH/oD6jnEtRePWqKWI0="
+    },
+    {
+        "address": "1568zfydB9n1LXhaSVc7zE7FZCqRpe5itX",
+        "wif": "L5ikWToVZK1b8heKDL6Y2WsF1sZhZQQAgUvqRrZFX9xMsSzZCD4w",
+        "signature": "H5biQUgDZfVtporZe0+WLk4TIpyibaYosQbIFIj6MiqVzXyj1l7T8Rav35fCE+B7rz/mFgmTYW/vTeMGd73MZaU="
+    },
+    {
+        "address": "1EpPQJeica4FeXTxPBtM2HcN1drGT9NiV6",
+        "wif": "L3YRxU1SUsyeVz9cV9BW5hyiFsh4atgoDKHivMxL862SPLKg3rXa",
+        "signature": "IHlNh6QsJT99x1Q8f36FAn3B+EDBS2oeBN2MCIGnLUFrVutUzUGaIs3/J9VfKKhXQArdnbrPrzor8vy65MvMDu0="
+    },
+    {
+        "address": "12duLneSfQWCuZwZriM9qK9wW99gMrNUig",
+        "wif": "L1MyJ25p5nzyuqkDHWbPCMA3dJWoGTPPX8M1PgsyHZygWFUyKQet",
+        "signature": "IIgkm9e762tsz6ZbhlvD06I4q+lu1X0qof9fk578SKYWx9j7P/qew/Xxzp9iwIHAdLPM7yuJTyTJOyVlgXT1Jt0="
+    },
+    {
+        "address": "14YZHZbrL9EzH6sCpmQbeutTBqrFB1dRdD",
+        "wif": "L4gYSCnBi35MCPRCfbDzPMmRvYBFWw9fQAxcvs4pYSCBc6SKD696",
+        "signature": "IEpeBqqPmjbVpMb2LaPjgDfUcpDuAuxdidFiR2Q34b4MpuWBQmFvsAwqbyn8vAV8883sFGO//LDqIPmZfnvxdkI="
+    },
+    {
+        "address": "1CiuEouXGWG1TR8iVo2reDe7ebcCqwcnPV",
+        "wif": "Kyn4mz682ahaoiNvkYuVZh3zRWRLCDSFyQaz6cAmcNLE2fV3QZhZ",
+        "signature": "HxRfJ73AFHPeiHasEN1r5Hp4heeLS/oQxcTDSX1K1X11oACPFQ6bG7iS1WV3PKmKKB4ZY/6WWfz2kE8mmHEVIIY="
+    },
+    {
+        "address": "1P3z6491LJ78McE3AXUA6YBjmtPgnhmPm",
+        "wif": "L4q49J2rR5waECqpCy2BqmY7rmw1y8TNRmqfsRVwGD6Hs1XFHHXs",
+        "signature": "IFb5K9hljcuW7vUE1d8TSJ3FvtK+Tbz+QX99/HuxkNE2kxF70S8dYMaUbibq9/9bmsnZa5UGJg1wFPUtPMI5jWE="
+    },
+    {
+        "address": "16qzDG8m63tTEv9rrYuzTumZTcWQwhnRMA",
+        "wif": "Kwk34zp3ZxBRwJWCE3iTHVz9X7ZwsAXcgkdiK6rBwSo7yAkMxCoK",
+        "signature": "Hxqa8KbHcpjOcmHwu6SI0e5M2uGUPKpN7DOJN6NkBY3Epqiz56a61NikoTarEqMZ7MA3JZbP/qYWN51hmkSaGXw="
+    },
+    {
+        "address": "1Emrg69U67pGoLApMqAHVRWc5XKy88B3rG",
+        "wif": "L4z6mmq5vBTNhWKQcu4ri7sBeZoqWoRJxFPzm4HovMidB7ioE5og",
+        "signature": "IGDbZp23n01SS8wcbiKBkVq0bXApo2/qwCoSQt5MhSQMSQHmduePO9qhG981//FuWZIX4X6Hkc/UWgfuZxeQ3h8="
+    },
+    {
+        "address": "14dcz4s1Uno7a1jqt1GxsLKahczMEVVNT8",
+        "wif": "L43ZM7uut9rEWNneSW3aT4mmNKfoKia8nbhpJNtA2TxFfaZtj9Eh",
+        "signature": "H9ekLjFd0ueGUb11IA1D94t6XpTxbVP6wuZQrvdilHRdAahZQEh5qL8xSGGLQ7IEtooDpuVcyeJYhSv3vfIgI6g="
+    },
+    {
+        "address": "1AZcwLLxSoXKGVBpxxbG83ZDgLZJEqzNQv",
+        "wif": "KxzNhnDuFRbFmoiogxQAvrPtDLX4CEiwHwiiYXte6VH8EU3jCzC8",
+        "signature": "H5HW+ZZosxwczxxsqYhq+UwHJEk1Sf2xIQhkGCCbEljKLrM+PeSsFFvVKHny9eTYuNaCgoXD21LtfqaJQZmxg0E="
+    },
+    {
+        "address": "1Net84z34Bz2Yz3o1fUeYauD1RgKFBUpyH",
+        "wif": "L3rRYDqdTXm4jvRg9qzUB2R9JX1eZf5RtmWoDgUtnmDHfSrpwgMb",
+        "signature": "HzgPoNDIe2QFdvRO+9YqlpWokioiZJETYAcSRboHgjlE/Il5vInuxRNxGkcbX9fu1mP3Nf3bH0v/en5EVzWRGlA="
+    },
+    {
+        "address": "1q5DjZfjqXSW83PkrncQqByJkuKnSc926",
+        "wif": "L5SLhsW38EKUz6ZpLCDx8PLqeyQCBMEfH2MKySidwHFqVvi7uoj8",
+        "signature": "HxxTt7XidQfjMLDmK6fsf0f57wD+5wJGEV0pNtzFrR7d5+V2/YvdB1BurjRxvSZTzp5o/7AAEQcqE/JvpBprWIw="
+    },
+    {
+        "address": "19ryK9RzvTeC7CZ1oRtw22ssCFWWYSGi29",
+        "wif": "KzTmDNoobwaHkEvLBwnbwKNm6Qutwndqw3NnyNg9yaCKnb7WMQWq",
+        "signature": "IFFeD6EQuyBjp0UU0t9gsYxiOzKSzEpIn30Kdy/pX4Z5pTrD/uxvO1k47sjFk513BVOCSFxWuqhFL5sNFq8aLSI="
+    },
+    {
+        "address": "1Pc9FnL4nys9sNxDv5uhVrUQJptTdgN3ur",
+        "wif": "L58gvLiGSZ3m3jRzo9Ypp7TDD9LGKMcAS45e1pFSQY8H4FUsr1kd",
+        "signature": "H+ZXwCyU90e21YL6S0n1bcJ208zsq8FWLBQU/sOicsIMFdYQ8jLCiA2ErG7hv2o7UCNVD1p0QmLD7H73SjX5kEs="
+    },
+    {
+        "address": "12Y7Vn7bZXs27H9bDVt1hSmEKmqfhjUHNr",
+        "wif": "L4mLCnkFYcTGWY7xWdrr9fhLqzQGfMwKbFivHaaUA3BMBvm625FY",
+        "signature": "H5Z2UZmRSvXCKJvFxaqsDw1rwtE20Ts2x2I/17Gl8ZrpBf8uFL/bfw2geBOSoEFU/uCVZOJj/GSHiW+vdWindik="
+    },
+    {
+        "address": "18TNP7QLezqsv3cvBsnrB7adJbPaZhQELj",
+        "wif": "L1fgADHELoBzLRDNiUvcXScW1tEpgLeBRJ79pWuNRUqQ7RC5fgVQ",
+        "signature": "H2HcMFessphuTqJLLxhdxM9j3KFKmTFvkigLB+L/JJQ5u/RlqzMeFkvEjVVHZtXhm1KLdYYsCIPvgh/5MTLc0lY="
+    },
+    {
+        "address": "1NYDPFBSvtEx3DtAaevqN8c4DMdMHNZz3H",
+        "wif": "Ky6G8MAnacN9aAhpiFYYYgVMyp2YoQAmmSau6f9DJygP74FBa1ob",
+        "signature": "H/hilSsA20DUX/O2AGVvnAgsndt9Talirx5PIEYc3QTIxuK5qaacH1UKuqvxyFk0/mDNBJCK1Zb6SB+XsmgfWHQ="
+    },
+    {
+        "address": "18hz5PkxYQWTPdVg3wPwtcpHpgxXGwYbPU",
+        "wif": "Kzj6ZSeXB6S38rNeQaAnDRnBEvhkpcwz8uksYC1uFKm45NFvmjHg",
+        "signature": "H2cNrEqNAyqiPISsxkNM8Siaj7H+J8cFe5ZID1bkk0Tsf0D2fLYUE4rjWxkI+3di2i1rGwUEJIsV9hb8CjaBHZs="
+    },
+    {
+        "address": "14yvK3MatK2u28nxZXfCNjyoyFuaGd4kU7",
+        "wif": "L5Hm3zXXpuiBrF4ywFTqh5L7D7WfW2UfcfWfDbQwNarJJg2Y5LVL",
+        "signature": "HzqB0gZfVAiKoXJ9Z5WGgz9EMAveMxF67gGReSpgr0zw1Mf7KA5inV0hPqA3lPRY4rmSOeKE0dBz2rFz0VawAwY="
+    },
+    {
+        "address": "1HEjBMwYBoWPT3JJH16MEZbQ2EutUX9sU4",
+        "wif": "KygyNuSYL82GrswYvb3w1ntpCmDaNEbwm4U5DKfWT6EGbBDz6oUE",
+        "signature": "H+K90IF2uu1NVj/fnpH1sn7gEEjJ+zhXN1JHjRq5QC2GBWx92ScHjCb9EsecARtsMdsIyBd/lRA5B/9KjGfZoZs="
+    },
+    {
+        "address": "1KCetUsMuMDXQiZqcA7TzQ8Gyvuo6ZgU9V",
+        "wif": "L2MEa6TKPY3BVMYH7h22cq64Wx9iGNEzTu1RRtWc1W3gSy3kV3ZJ",
+        "signature": "H23kt5yF2D6oCcSb4XpKGej9TAkspKbGaG/C3GSzduVMLnI7NltLeAbJqsIBCDP8qK3xRaqE1ZlHbn5ZJJcdvjs="
+    },
+    {
+        "address": "1LPQfNKdVEs5pYEzeszqCa5zfFZSouD5zF",
+        "wif": "KzqZiepEePG14E6HVt9uB7Nrq1XS9mCyaeAHC82jZZaNSLLjtCYK",
+        "signature": "IO3YOm+Zq/JLWGjWq4f2j2NKXJNvZ8LIjSiPO6p19DdcA+exSXWrfYs5GsvSkQlxEoYgHvCGlXJOdwdCnpktFMM="
+    },
+    {
+        "address": "12Hzw6UKBoJ3rhqvUczbr86y3HZu683t93",
+        "wif": "L5KgJJsJcpj3dHzdGUCJtShWSo4q6hCCZhLZqfbP2F3XgNSXVq6N",
+        "signature": "IB2+5oRrwyoAko9V1rwAvFAdujavO4QXqmKktcZjg2ap8dZkj7Y1XR+d3SNORCRrZ0DAsyE1yrjvd7yR8Xy19GU="
+    },
+    {
+        "address": "1CfY95vjs38hqmeaZndyM7PRRVumzgPkUC",
+        "wif": "L4p1pXiJq5STXefQekKCJajXwATg2wLwsPKHcWAuKUoGoNCRQvbF",
+        "signature": "H8kFuZeSJ7A7fiGzjgjvNHDDYXzFjxe/KLBxF5nB7Onpf/xndQ6KNeHcJD2xj0VoP1GVJKEI83ddXzt7svB53m4="
+    },
+    {
+        "address": "1JHaAQemw8o11ELAAcjosNLDzVqUU2dWW4",
+        "wif": "L144LBabTTCXk96x5HonRN7skfikcYqBN6X5ZqFXg9ag4bJFwdaj",
+        "signature": "HxQ+IxT9KAsGoBcJyKbC4VTzFAqEOFH3va1lw57kiywbs7XwsrojP91Md31jUM/U9pvosYceC6qaRvfG62arXa8="
+    }
+]

--- a/bitcoin/tests/test_signmessage.py
+++ b/bitcoin/tests/test_signmessage.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2013-2015 The python-bitcoinlib developers
+#
+# This file is part of python-bitcoinlib.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of python-bitcoinlib, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from bitcoin.wallet import CBitcoinSecret
+from bitcoin.signmessage import BitcoinMessage, VerifyMessage, SignMessage
+import sys
+import os
+import json
+
+_bchr = chr
+_bord = ord
+if sys.version > '3':
+    long = int
+    _bchr = lambda x: bytes([x])
+    _bord = lambda x: x
+
+def load_test_vectors(name):
+    with open(os.path.dirname(__file__) + '/data/' + name, 'r') as fd:
+        return json.load(fd)
+
+
+class Test_SignVerifyMessage(unittest.TestCase):
+    def test_verify_message_simple(self):
+        address = "1F26pNMrywyZJdr22jErtKcjF8R3Ttt55G"
+        message = address
+        signature = "H85WKpqtNZDrajOnYDgUY+abh0KCAcOsAIOQwx2PftAbLEPRA7mzXA/CjXRxzz0MC225pR/hx02Vf2Ag2x33kU4="
+
+        message = BitcoinMessage(message)
+
+        self.assertTrue(VerifyMessage(address, message, signature))
+
+    def test_verify_message_vectors(self):
+        for vector in load_test_vectors('signmessage.json'):
+            message = BitcoinMessage(vector['address'])
+            self.assertTrue(VerifyMessage(vector['address'], message, vector['signature']))
+
+    def test_sign_message_simple(self):
+        key = CBitcoinSecret("L4vB5fomsK8L95wQ7GFzvErYGht49JsCPJyJMHpB4xGM6xgi2jvG")
+        address = "1F26pNMrywyZJdr22jErtKcjF8R3Ttt55G"
+        message = address
+
+        message = BitcoinMessage(message)
+        signature = SignMessage(key, message)
+
+        self.assertTrue(signature)
+        self.assertTrue(VerifyMessage(address, message, signature))
+
+    def test_sign_message_vectors(self):
+        for vector in load_test_vectors('signmessage.json'):
+            key = CBitcoinSecret(vector['wif'])
+            message = BitcoinMessage(vector['address'])
+
+            signature = SignMessage(key, message)
+
+            self.assertTrue(signature, "Failed to sign for [%s]" % vector['address'])
+            self.assertTrue(VerifyMessage(vector['address'], message, vector['signature']), "Failed to verify signature for [%s]" % vector['address'])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bitcoin/wallet.py
+++ b/bitcoin/wallet.py
@@ -18,6 +18,7 @@ scriptPubKeys; currently there is no actual wallet support implemented.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
+
 _bord = ord
 if sys.version > '3':
     _bord = lambda x: x
@@ -221,6 +222,8 @@ class CKey(object):
     def sign(self, hash):
         return self._cec_key.sign(hash)
 
+    def sign_compact(self, hash):
+        return self._cec_key.sign_compact(hash)
 
 class CBitcoinSecretError(bitcoin.base58.Base58Error):
     pass

--- a/examples/sign-message.py
+++ b/examples/sign-message.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2013-2015 The python-bitcoinlib developers
+#
+# This file is part of python-bitcoinlib.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of python-bitcoinlib, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from bitcoin.wallet import CBitcoinSecret, P2PKHBitcoinAddress
+from bitcoin.signmessage import BitcoinMessage, VerifyMessage, SignMessage
+
+key = CBitcoinSecret("L4vB5fomsK8L95wQ7GFzvErYGht49JsCPJyJMHpB4xGM6xgi2jvG")
+address = P2PKHBitcoinAddress.from_pubkey(key.pub)  # "1F26pNMrywyZJdr22jErtKcjF8R3Ttt55G"
+message = "Hey I just met you, and this is crazy, but I'll verify my address, maybe ..."
+
+message = BitcoinMessage(message)
+
+signature = SignMessage(key, message)
+
+print(key, address)
+print("Address: %s" % address)
+print("Message: %s", message)
+print("\nSignature: %s" % signature)
+print("\nVerified: %s" % VerifyMessage(address, message, signature))
+
+print("\nTo verify using bitcoin core;")
+print("`bitcoin-cli verifymessage %s \"%s\" \"%s\"`" % (address, signature.decode('ascii'), message))


### PR DESCRIPTION
**Work in Progress**

I ported the code for pubkey recovery from bitcoin core using ctypes, the same way as the other code is written.

The `VerifyMessage` (and `BitcoinMessage` class) are still in the `test_signverify_message.py` because I have no idea where you would want these to go? please let me know where you want me to put them

I'm not entirely sure about the `CPubKey.recover_compact`, as a python dev I'd say it should be a `@classmethod` (like it is now) but to match the bitcoin core code (which is what you've been doing) should it be different?

tested against `py2.7` and `py3.4`, to test it against `libeay` I have to run it on windows I guess, or is it 100% certain that everything 'just works'?

PS. is there any particular reason for not having travis-ci setup to run the tests on the various python versions?