### PR TITLE
Add support for encoding to compact form

### DIFF
--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -311,9 +311,30 @@ def uint256_from_compact(c):
     Used for the nBits compact encoding of the target in the block header.
     """
     nbytes = (c >> 24) & 0xFF
-    v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
+    if nbytes <= 3:
+        v = (c & 0xFFFFFF) >> 8 * (3 - nbytes)
+    else:
+        v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
     return v
 
+def compact_from_uint256(v):
+    """Convert uint256 to compact encoding
+    """
+    nbytes = (v.bit_length() + 7) >> 3
+    compact = 0
+    if nbytes <= 3:
+        compact = (v & 0xFFFFFF) << 8 * (3 - nbytes)
+    else:
+        compact = v >> 8 * (nbytes - 3)
+        compact = compact & 0xFFFFFF
+
+    # If the sign bit (0x00800000) is set, divide the mantissa by 256 and
+    # increase the exponent to get an encoding without it set.
+    if compact & 0x00800000:
+        compact >>= 8
+        nbytes += 1
+
+    return compact | nbytes << 24
 
 def uint256_to_shortstr(u):
     s = "%064x" % (u,)
@@ -339,5 +360,6 @@ __all__ = (
         'VarStringSerializer',
         'uint256_from_str',
         'uint256_from_compact',
+        'compact_from_uint256',
         'uint256_to_shortstr',
 )

--- a/bitcoin/tests/test_serialize.py
+++ b/bitcoin/tests/test_serialize.py
@@ -107,3 +107,30 @@ class Test_BytesSerializer(unittest.TestCase):
         T(b'01')
         T(b'0200')
         T(b'ff00000000000000ff11223344', SerializationError) # > max_size
+
+class Test_Compact(unittest.TestCase):
+    def test_from_compact_zero(self):
+        self.assertEqual(uint256_from_compact(0x00123456), 0)
+        self.assertEqual(uint256_from_compact(0x01003456), 0)
+        self.assertEqual(uint256_from_compact(0x02000056), 0)
+        self.assertEqual(uint256_from_compact(0x03000000), 0)
+        self.assertEqual(uint256_from_compact(0x04000000), 0)
+        self.assertEqual(uint256_from_compact(0x00923456), 0)
+    def test_from_compact_negative_zero(self):
+        # Negative bit isn't supported yet
+        # self.assertEqual(uint256_from_compact(0x01803456), 0)
+        # self.assertEqual(uint256_from_compact(0x02800056), 0)
+        # self.assertEqual(uint256_from_compact(0x03800000), 0)
+        # self.assertEqual(uint256_from_compact(0x04800000), 0)
+        return
+
+    def test_twelve(self):
+        self.assertEqual(uint256_from_compact(0x01123456), 0x0012)
+        self.assertEqual(compact_from_uint256(0x0012), 0x01120000)
+
+    def test_from_uint256(self):
+        self.assertEqual(compact_from_uint256(0x1234), 0x02123400)
+        self.assertEqual(compact_from_uint256(0x123456), 0x03123456)
+        self.assertEqual(compact_from_uint256(0x12345600), 0x04123456)
+        self.assertEqual(compact_from_uint256(0x92340000), 0x05009234)
+        self.assertEqual(compact_from_uint256(0x1234560000000000000000000000000000000000000000000000000000000000), 0x20123456)


### PR DESCRIPTION
Add support for encoding uint256 values to compact form.
Add unit tests for compact for decode/encode
Add code to handle very small compact values (these are unlikely in real data, however should be handled anyway)