### PR TITLE
raise Exception when secp256k1 not supported

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -28,6 +28,13 @@ _ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('ssl') or 'libeay32')
 # this specifies the curve used with ECDSA.
 _NID_secp256k1 = 714 # from openssl/obj_mac.h
 
+# test that openssl support secp256k1
+if _ssl.EC_KEY_new_by_curve_name(_NID_secp256k1) == 0:
+    errno = _ssl.ERR_get_error()
+    errmsg = ctypes.create_string_buffer(120)
+    _ssl.ERR_error_string_n(errno, errmsg, 120)
+    raise RuntimeError('openssl error: %s' % errmsg.value)
+
 # Thx to Sam Devlin for the ctypes magic 64-bit fix.
 def _check_result (val, func, args):
     if val == 0:


### PR DESCRIPTION
In [Fedora](http://fedoraproject.org/) openssl not support secp256k1 by default..  (may be also in other fedora based os)
[Bug 1021898 - Enable curve secp256k1 ](https://bugzilla.redhat.com/show_bug.cgi?id=1021898) for details