### PR TITLE
Added createrawtransaction with user args.

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -218,6 +218,16 @@ class Proxy(RawProxy):
                                     timeout=timeout,
                                     **kwargs)
 
+    def createrawtransaction(self, *args):
+        """Get rawtransactions when provided vin and vout
+
+        FIXME: Implement options and accept outpoints instead of user args
+        """
+        r = self._call('createrawtransaction', *args)
+        r = str(r)
+        tx = CTransaction.deserialize(unhexlify(r))
+        return tx
+
     def dumpprivkey(self, addr):
         """Return the private key matching an address
         """

--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -219,7 +219,23 @@ class Proxy(RawProxy):
                                     **kwargs)
 
     def createrawtransaction(self, *args):
-        """Get rawtransactions when provided vin and vout
+        """Get rawtransactions when provided arguments, returns an object of
+        type CTransaction that can be used as an input for signrawtransaction.
+
+        Minimum required inputs.
+        1. List of transactions
+            [
+                {
+                    "txid": "id",
+                    "vout": n
+                }
+                ,...
+            ]
+        2. Dictionary of addresses with amounts being sent to each address
+            {
+                "address": x.xxx
+                ,....
+            }
 
         FIXME: Implement options and accept outpoints instead of user args
         """


### PR DESCRIPTION
Implemented wrapper for the `createrawtransaction` RPC, returns a transaction of type `CTransaction` which can be used as input for the `signrawtransaction` RPC. 

I'm unsure of how to use outpoints to provide input transactions, there's definitely a cleaner way than what I've mentioned in the comments.