### PR TITLE
NEEDS REVIEW - Fix #30. Replace ctypes with cryptography (cffi).

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -16,39 +16,47 @@ WARNING: This module does not mlock() secrets; your private keys may end up on
 disk in swap! Use with caution!
 """
 
-import ctypes
-import ctypes.util
 import hashlib
 import sys
+from cryptography.hazmat.bindings.openssl.binding import Binding
 
 import bitcoin.core.script
 
-_ssl = ctypes.cdll.LoadLibrary(ctypes.util.find_library('ssl') or 'libeay32')
+_binding = Binding()
+_ssl = _binding.lib
+_ffi = _binding.ffi
 
-# this specifies the curve used with ECDSA.
-_NID_secp256k1 = 714 # from openssl/obj_mac.h
+class OpenSSLError(Exception):
+    pass
+
+def _checksslerr(exc_type=OpenSSLError):
+    errno = _ssl.ERR_get_error()
+    if errno == 0:
+        return
+    _ssl.SSL_load_error_strings()
+    msgs = []
+    while errno != 0:
+        errmsg = _ffi.new('char[120]')
+        _ssl.ERR_error_string_n(errno, errmsg, 120)
+        msg = [
+            errno,
+            errmsg,
+            _ssl.ERR_lib_error_string(errno),
+            _ssl.ERR_func_error_string(errno),
+            _ssl.ERR_reason_error_string(errno),
+        ]
+        msg[1:] = [ _ffi.string(c) if c else None for c in msg[1:] ]
+        msgs.append(msg)
+        errno = _ssl.ERR_get_error()
+    if exc_type is not None:
+        raise exc_type(msgs)
 
 # test that openssl support secp256k1
-if _ssl.EC_KEY_new_by_curve_name(_NID_secp256k1) == 0:
-    errno = _ssl.ERR_get_error()
-    errmsg = ctypes.create_string_buffer(120)
-    _ssl.ERR_error_string_n(errno, errmsg, 120)
-    raise RuntimeError('openssl error: %s' % errmsg.value)
-
-# Thx to Sam Devlin for the ctypes magic 64-bit fix.
-def _check_result (val, func, args):
-    if val == 0:
-        raise ValueError
-    else:
-        return ctypes.c_void_p(val)
-
-_ssl.EC_KEY_new_by_curve_name.restype = ctypes.c_void_p
-_ssl.EC_KEY_new_by_curve_name.errcheck = _check_result
-
-# From openssl/ecdsa.h
-class ECDSA_SIG_st(ctypes.Structure):
-     _fields_ = [("r", ctypes.c_void_p),
-                ("s", ctypes.c_void_p)]
+_EC_GROUP_secp256k1 = _ssl.EC_GROUP_new_by_curve_name(_ssl.NID_secp256k1)
+if _EC_GROUP_secp256k1 == 0:
+    _checksslerr()
+else:
+    _ssl.EC_GROUP_free(_EC_GROUP_secp256k1)
 
 class CECKey:
     """Wrapper around OpenSSL's EC_KEY"""
@@ -57,55 +65,85 @@ class CECKey:
     POINT_CONVERSION_UNCOMPRESSED = 4
 
     def __init__(self):
-        self.k = _ssl.EC_KEY_new_by_curve_name(_NID_secp256k1)
-
-    def __del__(self):
-        if _ssl:
-            _ssl.EC_KEY_free(self.k)
-        self.k = None
+        self.k = _ffi.gc(_ssl.EC_KEY_new_by_curve_name(_ssl.NID_secp256k1), _ssl.EC_KEY_free)
 
     def set_secretbytes(self, secret):
-        priv_key = _ssl.BN_bin2bn(secret, 32, _ssl.BN_new())
+        priv_key = _ffi.gc(_ssl.BN_bin2bn(secret, min(len(secret), 32), _ffi.NULL), _ssl.BN_free)
         group = _ssl.EC_KEY_get0_group(self.k)
-        pub_key = _ssl.EC_POINT_new(group)
-        ctx = _ssl.BN_CTX_new()
-        if not _ssl.EC_POINT_mul(group, pub_key, priv_key, None, None, ctx):
-            raise ValueError("Could not derive public key from the supplied secret.")
-        _ssl.EC_POINT_mul(group, pub_key, priv_key, None, None, ctx)
+        pub_key = _ffi.gc(_ssl.EC_POINT_new(group), _ssl.EC_POINT_free)
+        bn_ctx = _ffi.gc(_ssl.BN_CTX_new(), _ssl.BN_CTX_free)
+        _ssl.EC_POINT_mul(group, pub_key, priv_key, _ffi.NULL, _ffi.NULL, bn_ctx)
+        _checksslerr()
+        _ssl.EC_POINT_mul(group, pub_key, priv_key, _ffi.NULL, _ffi.NULL, bn_ctx)
+        _checksslerr()
         _ssl.EC_KEY_set_private_key(self.k, priv_key)
+        _checksslerr()
         _ssl.EC_KEY_set_public_key(self.k, pub_key)
-        _ssl.EC_POINT_free(pub_key)
-        _ssl.BN_CTX_free(ctx)
+        _checksslerr()
         return self.k
 
     def set_privkey(self, key):
-        self.mb = ctypes.create_string_buffer(key)
-        return _ssl.d2i_ECPrivateKey(ctypes.byref(self.k), ctypes.byref(ctypes.pointer(self.mb)), len(key))
+        if hasattr(_ssl, 'd2i_ECPrivateKey'):
+            k = _ssl.d2i_ECPrivateKey(_ffi.NULL, [key], len(key))
+        else:
+            # TODO: alternate implementation?
+            raise RuntimeError('d2i_ECPrivateKey unsupported by this version of cryptography')
+        _checksslerr()
+        self.k = _ffi.gc(k, _ssl.EC_KEY_free)
+        return self.k
 
     def set_pubkey(self, key):
-        self.mb = ctypes.create_string_buffer(key)
-        return _ssl.o2i_ECPublicKey(ctypes.byref(self.k), ctypes.byref(ctypes.pointer(self.mb)), len(key))
+        if hasattr(_ssl, 'o2i_ECPublicKey'):
+            _ssl.o2i_ECPublicKey([self.k], [key], len(key))
+        else:
+            group = _ssl.EC_KEY_get0_group(self.k)
+            point = _ffi.gc(_ssl.EC_POINT_new(group), _ssl.EC_POINT_free)
+            _ssl.EC_POINT_oct2point(group, point, key, len(key), _ffi.NULL)
+            _checksslerr()
+            _ssl.EC_KEY_set_public_key(self.k, point)
+        return self.k
 
     def get_privkey(self):
-        size = _ssl.i2d_ECPrivateKey(self.k, 0)
-        mb_pri = ctypes.create_string_buffer(size)
-        _ssl.i2d_ECPrivateKey(self.k, ctypes.byref(ctypes.pointer(mb_pri)))
-        return mb_pri.raw
+        if hasattr(_ssl, 'i2d_ECPrivateKey'):
+            size = _ssl.i2d_ECPrivateKey(self.k, _ffi.NULL)
+        else:
+            # TODO: alternate implementation?
+            raise RuntimeError('i2d_ECPrivateKey unsupported by this version of cryptography')
+        _checksslerr()
+        uc_buf = _ffi.new('unsigned char[]', size)
+        if hasattr(_ssl, 'i2d_ECPrivateKey'):
+            _ssl.i2d_ECPrivateKey(self.k, [uc_buf])
+        else:
+            # TODO: alternate implementation?
+            raise RuntimeError('i2d_ECPrivateKey unsupported by this version of cryptography')
+        _checksslerr()
+        return _ffi.buffer(uc_buf, size)[:]
 
     def get_pubkey(self):
-        size = _ssl.i2o_ECPublicKey(self.k, 0)
-        mb = ctypes.create_string_buffer(size)
-        _ssl.i2o_ECPublicKey(self.k, ctypes.byref(ctypes.pointer(mb)))
-        return mb.raw
+        if hasattr(_ssl, 'i2o_ECPublicKey'):
+            size = _ssl.i2o_ECPublicKey(self.k, _ffi.NULL)
+        else:
+            conv_form = _ssl.EC_KEY_get_conv_form(self.k)
+            group = _ssl.EC_KEY_get0_group(self.k)
+            pub_key = _ssl.EC_KEY_get0_public_key(self.k)
+            size = _ssl.EC_POINT_point2oct(group, pub_key, conv_form, _ffi.NULL, 0, _ffi.NULL)
+        _checksslerr()
+        uc_buf = _ffi.new('unsigned char[]', size)
+        if hasattr(_ssl, 'i2o_ECPublicKey'):
+            _ssl.i2o_ECPublicKey(self.k, [uc_buf])
+        else:
+            _ssl.EC_POINT_point2oct(group, pub_key, conv_form, uc_buf, size, _ffi.NULL)
+        _checksslerr()
+        return _ffi.buffer(uc_buf, size)[:]
 
     def get_raw_ecdh_key(self, other_pubkey):
-        ecdh_keybuffer = ctypes.create_string_buffer(32)
-        r = _ssl.ECDH_compute_key(ctypes.pointer(ecdh_keybuffer), 32,
+        ecdh_key_buf = _ffi.new('unsigned char[]', 32)
+        r = _ssl.ECDH_compute_key(ecdh_key_buf, 32,
                                  _ssl.EC_KEY_get0_public_key(other_pubkey.k),
-                                 self.k, 0)
+                                 self.k, _ffi.NULL)
         if r != 32:
-            raise Exception('CKey.get_ecdh_key(): ECDH_compute_key() failed')
-        return ecdh_keybuffer.raw
+            raise RuntimeError('CKey.get_ecdh_key(): ECDH_compute_key() failed')
+        return _ffi.buffer(ecdh_key_buf, 32)[:]
 
     def get_ecdh_key(self, other_pubkey, kdf=lambda k: hashlib.sha256(k).digest()):
         # FIXME: be warned it's not clear what the kdf should be as a default
@@ -118,65 +156,73 @@ class CECKey:
         if len(hash) != 32:
             raise ValueError('Hash must be exactly 32 bytes long')
 
-        sig_size0 = ctypes.c_uint32()
-        sig_size0.value = _ssl.ECDSA_size(self.k)
-        mb_sig = ctypes.create_string_buffer(sig_size0.value)
-        result = _ssl.ECDSA_sign(0, hash, len(hash), mb_sig, ctypes.byref(sig_size0), self.k)
+        sig_size0_p = _ffi.new('unsigned int*')
+        sig_size0_p[0] = _ssl.ECDSA_size(self.k)
+        _checksslerr()
+        uc_buf = _ffi.new('unsigned char[]', sig_size0_p[0])
+        result = _ssl.ECDSA_sign(0, hash, len(hash), uc_buf, sig_size0_p, self.k)
+        _checksslerr()
+        mb_sig = _ffi.buffer(uc_buf, sig_size0_p[0])[:]
         assert 1 == result
-        if bitcoin.core.script.IsLowDERSignature(mb_sig.raw[:sig_size0.value]):
-            return mb_sig.raw[:sig_size0.value]
+        if bitcoin.core.script.IsLowDERSignature(mb_sig):
+            return mb_sig
         else:
-            return self.signature_to_low_s(mb_sig.raw[:sig_size0.value])
+            return self.signature_to_low_s(uc_buf, sig_size0_p[0])
 
-    def signature_to_low_s(self, sig):
-        der_sig = ECDSA_SIG_st()
-        _ssl.d2i_ECDSA_SIG(ctypes.byref(ctypes.pointer(der_sig)), ctypes.byref(ctypes.c_char_p(sig)), len(sig))
+    def signature_to_low_s(self, sig_buf, sig_buf_len):
+        der_sig = _ssl.d2i_ECDSA_SIG(_ffi.NULL, [sig_buf], sig_buf_len)
+        _checksslerr()
+        der_sig = _ffi.gc(der_sig, _ssl.ECDSA_SIG_free)
         group = _ssl.EC_KEY_get0_group(self.k)
-        order = _ssl.BN_new()
-        halforder = _ssl.BN_new()
-        ctx = _ssl.BN_CTX_new()
-        _ssl.EC_GROUP_get_order(group, order, ctx)
+        order = _ffi.gc(_ssl.BN_new(), _ssl.BN_free)
+        halforder = _ffi.gc(_ssl.BN_new(), _ssl.BN_free)
+        bn_ctx = _ffi.gc(_ssl.BN_CTX_new(), _ssl.BN_CTX_free)
+        _ssl.EC_GROUP_get_order(group, order, bn_ctx)
         _ssl.BN_rshift1(halforder, order)
 
         # Verify that s is over half the order of the curve before we actually subtract anything from it
         if _ssl.BN_cmp(der_sig.s, halforder) > 0:
           _ssl.BN_sub(der_sig.s, order, der_sig.s)
 
-        _ssl.BN_free(halforder)
-        _ssl.BN_free(order)
-        _ssl.BN_CTX_free(ctx)
-
-        derlen = _ssl.i2d_ECDSA_SIG(ctypes.pointer(der_sig), 0)
+        derlen = _ssl.i2d_ECDSA_SIG(der_sig, _ffi.NULL)
+        _checksslerr()
         if derlen == 0:
-            _ssl.ECDSA_SIG_free(der_sig)
             return None
-        new_sig = ctypes.create_string_buffer(derlen)
-        _ssl.i2d_ECDSA_SIG(ctypes.pointer(der_sig), ctypes.byref(ctypes.pointer(new_sig)))
-        _ssl.BN_free(der_sig.r)
-        _ssl.BN_free(der_sig.s)
+        new_sig_buf = _ffi.new('unsigned char[]', derlen)
+        _ssl.i2d_ECDSA_SIG(der_sig, [new_sig_buf])
+        _checksslerr()
 
-        return new_sig.raw
+        return _ffi.buffer(new_sig_buf, derlen)[:]
 
     def verify(self, hash, sig):
         """Verify a DER signature"""
         if not sig:
-          return false
+          return False
 
         # New versions of OpenSSL will reject non-canonical DER signatures. de/re-serialize first.
-        norm_sig = ctypes.c_void_p(0)
-        _ssl.d2i_ECDSA_SIG(ctypes.byref(norm_sig), ctypes.byref(ctypes.c_char_p(sig)), len(sig))
+        norm_sig_p = _ffi.new('ECDSA_SIG**')
+        c_sig = _ffi.new('char[]', len(sig))
+        c_sig[0:len(sig)] = sig
+        uc_sig = _ffi.cast('unsigned char*', c_sig)
+        _ssl.d2i_ECDSA_SIG(norm_sig_p, [uc_sig], len(sig))
+        _checksslerr()
 
-        derlen = _ssl.i2d_ECDSA_SIG(norm_sig, 0)
+        derlen = _ssl.i2d_ECDSA_SIG(norm_sig_p[0], _ffi.NULL)
+        _checksslerr()
         if derlen == 0:
-            _ssl.ECDSA_SIG_free(norm_sig)
-            return false
+            _ssl.ECDSA_SIG_free(norm_sig_p[0])
+            return False
 
-        norm_der = ctypes.create_string_buffer(derlen)
-        _ssl.i2d_ECDSA_SIG(norm_sig, ctypes.byref(ctypes.pointer(norm_der)))
-        _ssl.ECDSA_SIG_free(norm_sig)
+        uc_der = _ffi.new('unsigned char[]', derlen)
+        _ssl.i2d_ECDSA_SIG(norm_sig_p[0], [uc_der])
+        _checksslerr()
+        _ssl.ECDSA_SIG_free(norm_sig_p[0])
+        _checksslerr()
+        verify_res = _ssl.ECDSA_verify(0, hash, len(hash), uc_der, derlen, self.k)
+        _checksslerr()
 
         # -1 = error, 0 = bad sig, 1 = good
-        return _ssl.ECDSA_verify(0, hash, len(hash), norm_der, derlen, self.k) == 1
+        return verify_res == 1
 
     def set_compressed(self, compressed):
         if compressed:
@@ -201,7 +247,11 @@ class CPubKey(bytes):
         if _cec_key is None:
             _cec_key = CECKey()
         self._cec_key = _cec_key
-        self.is_fullyvalid = _cec_key.set_pubkey(self) != 0
+        try:
+            _cec_key.set_pubkey(self)
+            self.is_fullyvalid = True
+        except OpenSSLError:
+            self.is_fullyvalid = False
         return self
 
     @property

--- a/bitcoin/core/scripteval.py
+++ b/bitcoin/core/scripteval.py
@@ -114,10 +114,13 @@ def _CastToBool(s):
 
 
 def _CheckSig(sig, pubkey, script, txTo, inIdx, err_raiser):
-    key = bitcoin.core.key.CECKey()
-    key.set_pubkey(pubkey)
-
+    # See TX cc60b1f899ec0a69b7c3f25ddf32c4524096a9c5b01cbd84c6d0312a0c478984
     if len(sig) == 0:
+        return False
+    key = bitcoin.core.key.CECKey()
+    try:
+        key.set_pubkey(pubkey)
+    except bitcoin.core.key.OpenSSLError:
         return False
     hashtype = _bord(sig[-1])
     sig = sig[:-1]

--- a/bitcoin/tests/test_transactions.py
+++ b/bitcoin/tests/test_transactions.py
@@ -136,7 +136,6 @@ class Test_CTransaction(unittest.TestCase):
 
                 VerifyScript(tx.vin[i].scriptSig, prevouts[tx.vin[i].prevout], tx, i, flags=flags)
 
-
     def test_tx_invalid(self):
         for prevouts, tx, enforceP2SH in load_test_vectors('tx_invalid.json'):
             try:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README')) as f:
     README = f.read()
 
-requires = []
+requires = [
+    'cryptography',
+]
 
 setup(name='python-bitcoinlib',
       version='0.4.1-SNAPSHOT',


### PR DESCRIPTION
Fix #30. Replace `ctypes` with [`cryptography`](/pyca/cryptography) (`cffi`).

```sh
% python2.7 -m unittest discover && python3.4 -m unittest discover
..................................................................................................
----------------------------------------------------------------------
Ran 98 tests in 0.565s

OK
..................................................................................................
----------------------------------------------------------------------
Ran 98 tests in 0.502s

OK
```

There is currently one known issue: [`CECKey.set_privkey`](https://github.com/posita/python-bitcoinlib/blob/use-pyca-cryptography-for-bignum-ops-30/bitcoin/core/key.py#L85) and [`CECKey.get_privkey`](https://github.com/posita/python-bitcoinlib/blob/use-pyca-cryptography-for-bignum-ops-30/bitcoin/core/key.py#L106) require the `FFI` instance to expose the `d2i_ECPrivateKey` and `i2d_ECPrivateKey` functions, respectively, from the underlying OpenSSL library. *Currently, [`cryptography`](/pyca/cryptography) does not expose these functions.* This means that those functions will not work. I have not yet investigated or considered using a hybrid `ctypes` approach for that narrow set of functionality (if that is even possible).

This only affects the `*_privkey` getter and setter. I was able to provide alternatives to the `o2i_ECPublicKey` and `i2o_ECPublicKey` functions used in the corresponding `*_pubkey` functions (see [this](https://github.com/posita/python-bitcoinlib/blob/use-pyca-cryptography-for-bignum-ops-30/bitcoin/core/key.py#L98) and [this](https://github.com/posita/python-bitcoinlib/blob/use-pyca-cryptography-for-bignum-ops-30/bitcoin/core/key.py#L125)). I have not yet found (or am not clever enough to recognize) equivalents on the private key side.

The reason why unit tests still pass is because the `*_privkey` getter and setter are not called from any of the tests. This is unchanged from before (I did not add tests to cover those methods).