### PR TITLE
Update importaddress rpc call to handle no label, rescan=False

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -388,17 +388,11 @@ class Proxy(RawProxy):
         r['bestblock'] = lx(r['bestblock'])
         return r
 
-    def importaddress(self, addr, label=None, rescan=True):
+    def importaddress(self, addr, label='', rescan=True):
         """Adds an address or pubkey to wallet without the associated privkey."""
         addr = str(addr)
 
-        if label is not None:
-            if rescan:
-                r = self._call('importaddress', addr, label, True)
-            else:
-                r = self._call('importaddress', addr, label)
-        else:
-            r = self._call('importaddress', addr)
+        r = self._call('importaddress', addr, label, rescan)
         return r
 
     def listunspent(self, minconf=0, maxconf=9999999, addrs=None):


### PR DESCRIPTION
Because the importaddress RPC call requires having something in the label parameter in order to check the rescan parameter, I changed the default value of label to an empty string. The code now sends an RPC call with all of the parameters every time, such that all cases are handled properly.

Alternatively, the default value can remain None, but this would require if-else spaghetti.