### PR TITLE
Two minor bugs:

### DIFF
--- a/bitcoin/messages.py
+++ b/bitcoin/messages.py
@@ -102,7 +102,7 @@ class MsgSerializable(Serializable):
             #        print("Going to deserialize '%s'" % msg)
             return cls.msg_deser(_BytesIO(msg))
         else:
-            print("Command '%s' not in messagemap" % str(command, 'ascii'))
+            print("Command '%s' not in messagemap" % repr(command))
             return None
 
     def stream_serialize(self, f):
@@ -335,11 +335,13 @@ class msg_headers(MsgSerializable):
     @classmethod
     def msg_deser(cls, f, protover=PROTO_VERSION):
         c = cls()
-        c.headers = VectorSerializer.stream_deserialize(CBlock, f)
+        c.headers = VectorSerializer.stream_deserialize(CBlockHeader, f)
         return c
 
     def msg_ser(self, f):
-        VectorSerializer.stream_serialize(CBlock, self.headers, f)
+        VectorSerializer.stream_serialize(CBlockHeader, self.headers, f)
+        # Should be zero according to https://en.bitcoin.it/wiki/Protocol_documentation#Block_Headers
+        f.write('\x00')
 
     def __repr__(self):
         return "msg_headers(headers=%s)" % (repr(self.headers))


### PR DESCRIPTION
1. str(command, 'ascii') doesn't work with python2
2. BlockHeaders could not be sent in the headers message because they were missing a zero at the end

I realize that this is not the most elegant fix for the BlockHeaders but putting it in another place either broke the block generation or the GetHash for the BlockHeaders.

Anyway, thanks for the great library.