### PR TITLE
Small fix to serialization and deserialization of BlockHeader

### DIFF
--- a/bitcoin/messages.py
+++ b/bitcoin/messages.py
@@ -335,11 +335,16 @@ class msg_headers(MsgSerializable):
     @classmethod
     def msg_deser(cls, f, protover=PROTO_VERSION):
         c = cls()
-        c.headers = VectorSerializer.stream_deserialize(CBlock, f)
+        c.headers = VectorSerializer.stream_deserialize(CBlockHeader, f)
+        # Read 0 byte at the end
+        terminator = ser_read(f, 1)
+        assert(terminator == '\x00')
         return c
 
     def msg_ser(self, f):
-        VectorSerializer.stream_serialize(CBlock, self.headers, f)
+        VectorSerializer.stream_serialize(CBlockHeader, self.headers, f)
+        # Should be zero according to https://en.bitcoin.it/wiki/Protocol_documentation#Block_Headers
+        f.write('\x00')
 
     def __repr__(self):
         return "msg_headers(headers=%s)" % (repr(self.headers))


### PR DESCRIPTION
Follow-up on:
https://github.com/petertodd/python-bitcoinlib/pull/66

I added the part in the deserialization.

I also tested that serialization and deserialization match now:
https://github.com/ritzdorf/python-bitcoinlib/commit/24561e637690e5ccdc04b9a24f766e57d4f18baa

