### PR TITLE
READY FOR REVIEW - Add tox support for coverage and multiple python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@
 
 local*.cfg
 
+.coverage
+.tox/
 build/
+htmlcov/
 python_bitcoinlib.egg-info/

--- a/README
+++ b/README
@@ -111,6 +111,22 @@ Under bitcoin/tests using test data from Bitcoin Core. To run them:
 
 Please run the tests on both Python2 and Python3 for your pull-reqs!
 
+Alternately, if Tox (see https://tox.readthedocs.org/) is available on your
+system, you can run unit tests for multiple Python versions:
+
+    ./runtests.sh
+
+Currently, the following implementations are tried (any not installed are
+skipped):
+
+    * CPython 2.7
+    * CPython 3.3
+    * CPython 3.4
+    * CPython 3.5
+    * PyPy
+    * PyPy3
+
+HTML coverage reports can then be found in the htmlcov/ subdirectory.
 
 Documentation
 -------------

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+#-*-mode: sh; encoding: utf-8-*-
+
+_MY_DIR="$( cd "$( dirname "${0}" )" && pwd )"
+set -ex
+[ -d "${_MY_DIR}" ]
+[ "${_MY_DIR}/runtests.sh" -ef "${0}" ]
+cd "${_MY_DIR}"
+exec tox ${1+"${@}"}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+#-*-mode: ini; encoding: utf-8-*-
+
+[tox] #-------------------------------------------------------------------
+
+envlist = reset,py27,py33,py34,py35,pypy,pypy3,stats
+skip_missing_interpreters = True
+
+[testenv] #---------------------------------------------------------------
+
+commands =
+    coverage run --append --omit='tests/*,*/site-packages/*,*/distutils/*,*/lib_pypy/*' setup.py test -q
+
+deps =
+    coverage
+
+setenv =
+    PYTHONWARNINGS = all
+
+[testenv:reset] #---------------------------------------------------------
+
+commands =
+    coverage erase
+
+[testenv:stats] #---------------------------------------------------------
+
+commands =
+    coverage report
+    coverage html


### PR DESCRIPTION
Add tox support for automating tests across multiple Python versions and for gathering coverage statistics.

This is what I used for reproducing #30 and for testing #77 and #79. I thought I'd share in case it was useful.