### PR TITLE
Fix getinfo() RPC where disablewallet=1

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -355,7 +355,8 @@ class Proxy(BaseProxy):
         r = self._call('getinfo')
         if 'balance' in r:
             r['balance'] = int(r['balance'] * COIN)
-        r['paytxfee'] = int(r['paytxfee'] * COIN)
+        if 'paytxfee' in r:
+            r['paytxfee'] = int(r['paytxfee'] * COIN)
         return r
 
     def getmininginfo(self):


### PR DESCRIPTION
For daemons without a wallet the 'paytxfee' field does not exist. 