### PR TITLE
Fixing two typos

### DIFF
--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -160,11 +160,11 @@ class COutPoint(ImmutableSerializable):
     def from_outpoint(cls, outpoint):
         """Create an immutable copy of an existing OutPoint
 
-        If output is already immutable (outpoint.__class__ is COutPoint) it is
+        If outpoint is already immutable (outpoint.__class__ is COutPoint) it is
         returned directly.
         """
-        if output.__class__ is COutPoint:
-            return output
+        if outpoint.__class__ is COutPoint:
+            return outpoint
 
         else:
             return cls(outpoint.hash, outpoint.n)

--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -217,7 +217,7 @@ class CECKey:
     def verify(self, hash, sig):
         """Verify a DER signature"""
         if not sig:
-          return false
+            return False
 
         # New versions of OpenSSL will reject non-canonical DER signatures. de/re-serialize first.
         norm_sig = ctypes.c_void_p(0)
@@ -226,7 +226,7 @@ class CECKey:
         derlen = _ssl.i2d_ECDSA_SIG(norm_sig, 0)
         if derlen == 0:
             _ssl.ECDSA_SIG_free(norm_sig)
-            return false
+            return False
 
         norm_der = ctypes.create_string_buffer(derlen)
         _ssl.i2d_ECDSA_SIG(norm_sig, ctypes.byref(ctypes.pointer(norm_der)))


### PR DESCRIPTION
In bitcoin/core/__init__.py COutPoint's from_outpoint class method has references to an output. I'm assuming this is vestigial unless the intended method is from_output.

bitcoin/core/key.py had a couple of lower cased False constants