### PR TITLE
Adds subtractfeefromamount to sendtoaddress

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -534,11 +534,11 @@ class Proxy(BaseProxy):
         r = self._call('sendmany', fromaccount, json_payments, minconf, comment)
         return lx(r)
 
-    def sendtoaddress(self, addr, amount):
+    def sendtoaddress(self, addr, amount, subtractfeefromamount=False):
         """Sent amount to a given address"""
         addr = str(addr)
         amount = float(amount)/COIN
-        r = self._call('sendtoaddress', addr, amount)
+        r = self._call('sendtoaddress', addr, amount, subtractfeefromamount)
         return lx(r)
 
     def signrawtransaction(self, tx, *args):


### PR DESCRIPTION
Wasn't sure which branch to create pull request from.

This change adds the ability to roll up the transaction fee into the amount rather than add it on top of the transaction. It is supported in bitcoind 0.11+ but was missing in the library.