### PR TITLE
Adds sendtoaddress options comments, subtractfeefromamount

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -527,18 +527,18 @@ class Proxy(BaseProxy):
             r = self._call('sendrawtransaction', hextx)
         return lx(r)
 
-    def sendmany(self, fromaccount, payments, minconf=1, comment=''):
+    def sendmany(self, fromaccount, payments, minconf=1, comment='', subtractfeefromamount=False):
         """Sent amount to a given address"""
         json_payments = {str(addr):float(amount)/COIN
                          for addr, amount in payments.items()}
-        r = self._call('sendmany', fromaccount, json_payments, minconf, comment)
+        r = self._call('sendmany', fromaccount, json_payments, minconf, comment, subtractfeefromamount)
         return lx(r)
 
-    def sendtoaddress(self, addr, amount):
+    def sendtoaddress(self, addr, amount, comment='', commentto='', subtractfeefromamount=False):
         """Sent amount to a given address"""
         addr = str(addr)
         amount = float(amount)/COIN
-        r = self._call('sendtoaddress', addr, amount)
+        r = self._call('sendtoaddress', addr, amount, comment, commentto, subtractfeefromamount)
         return lx(r)
 
     def signrawtransaction(self, tx, *args):


### PR DESCRIPTION
This pull request fills out newly added option **subtractfeefromamount** introduced in Bitcoin 0.11. It is used in the *sendmany* and *sendtoaddress* calls and will subtract the transaction fee from the amount rather than adding it on top of it. Since the target bitcoin version is 0.11 this should be safe for installs. 

Without adding these options it will retain existing functionality. Also had to add the comment parameters for *sendtoaddress* which were missing.

Ran the runtests.sh for this pull request, not sure what this all means, but the changes are simple and I've tested on my app.

```
Name                                 Stmts   Miss  Cover
--------------------------------------------------------
bitcoin/__init__.py                     31      8    74%
bitcoin/base58.py                       77      2    97%
bitcoin/bloom.py                       104     14    87%
bitcoin/core/__init__.py               398     39    90%
bitcoin/core/_bignum.py                 69      2    97%
bitcoin/core/key.py                    362     52    86%
bitcoin/core/script.py                 419     18    96%
bitcoin/core/scripteval.py             463     24    95%
bitcoin/core/serialize.py              194     23    88%
bitcoin/messages.py                    345     31    91%
bitcoin/net.py                         131     54    59%
bitcoin/rpc.py                         283    209    26%
bitcoin/signature.py                    30      6    80%
bitcoin/signmessage.py                  40      5    88%
bitcoin/tests/__init__.py                1      0   100%
bitcoin/tests/test_base58.py            32      0   100%
bitcoin/tests/test_bloom.py             61      0   100%
bitcoin/tests/test_checkblock.py        35      6    83%
bitcoin/tests/test_core.py              76      0   100%
bitcoin/tests/test_key.py               19      0   100%
bitcoin/tests/test_messages.py          79      0   100%
bitcoin/tests/test_net.py               45      0   100%
bitcoin/tests/test_rpc.py                5      0   100%
bitcoin/tests/test_script.py           310      0   100%
bitcoin/tests/test_scripteval.py        51      3    94%
bitcoin/tests/test_serialize.py        100      1    99%
bitcoin/tests/test_signmessage.py       44      1    98%
bitcoin/tests/test_transactions.py     100      3    97%
bitcoin/tests/test_wallet.py           127      0   100%
bitcoin/wallet.py                      116      9    92%
setup.py                                 8      0   100%
--------------------------------------------------------
TOTAL                                 4155    510    88%
stats runtests: commands[1] | coverage html
________________________________________________________________________________ summary _________________________________________________________________________________
  reset: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
SKIPPED:  py35: InterpreterNotFound: python3.5
SKIPPED:  pypy: InterpreterNotFound: pypy
SKIPPED:  pypy3: InterpreterNotFound: pypy3
  stats: commands succeeded
  congratulations :)
```

Should be straightforward but let me know if you have any questions. 