### PR TITLE
Fixed a bug in bloom filter deserialization

### DIFF
--- a/bitcoin/bloom.py
+++ b/bitcoin/bloom.py
@@ -56,7 +56,6 @@ def MurmurHash3(nHashSeed, vDataToHash):
     # tail
     k1 = 0
     j = (len(vDataToHash) // 4) * 4
-    import sys
     bord = ord
     if sys.version > '3':
         # In Py3 indexing bytes returns numbers, not characters
@@ -123,6 +122,7 @@ class CBloomFilter(bitcoin.core.serialize.Serializable):
         return MurmurHash3(((nHashNum * 0xFBA4C795) + self.nTweak) & 0xFFFFFFFF, vDataToHash) % (len(self.vData) * 8)
 
     __bit_mask = bytearray([0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80])
+
     def insert(self, elem):
         """Insert an element in the filter.
 
@@ -164,18 +164,20 @@ class CBloomFilter(bitcoin.core.serialize.Serializable):
         raise NotImplementedError
 
     __struct = struct.Struct(b'<IIB')
+
     @classmethod
     def stream_deserialize(cls, f):
-        vData = bitcoin.core.serialize.BytesSerializer.stream_deserialize(f)
+        vData = bytearray(bitcoin.core.serialize.BytesSerializer.stream_deserialize(f))
         (nHashFuncs,
          nTweak,
-         nFlags) = self.__struct.unpack(_ser_read(f, self.__struct.size))
-        self = cls()
-        self.vData = vData
-        self.nHashFuncs = nHashFuncs
-        self.nTweak = nTweak
-        self.nFlags = nFlags
-        return self
+         nFlags) = CBloomFilter.__struct.unpack(bitcoin.core.ser_read(f, CBloomFilter.__struct.size))
+        # These arguments can be fake, the real values are set just after
+        deserialized = cls(1, 0.01, 0, CBloomFilter.UPDATE_ALL)
+        deserialized.vData = vData
+        deserialized.nHashFuncs = nHashFuncs
+        deserialized.nTweak = nTweak
+        deserialized.nFlags = nFlags
+        return deserialized
 
     def stream_serialize(self, f):
         if sys.version > '3':

--- a/bitcoin/tests/test_bloom.py
+++ b/bitcoin/tests/test_bloom.py
@@ -63,6 +63,12 @@ class Test_CBloomFilter(unittest.TestCase):
         T('b9300670b4c5366e95b2699e8b18bc75e5f729c5')
 
         self.assertEqual(filter.serialize(), x('03614e9b050000000000000001'))
+        deserialized = CBloomFilter.deserialize(x('03614e9b050000000000000001'))
+
+        self.assertTrue(deserialized.contains(x('99108ad8ed9bb6274d3980bab5a85c048f0950c8')))
+        self.assertFalse(deserialized.contains(x('19108ad8ed9bb6274d3980bab5a85c048f0950c8')))
+        self.assertTrue(deserialized.contains(x('b5a2c786d9ef4658287ced5914b37a1b4aa32eee')))
+        self.assertTrue(deserialized.contains(x('b9300670b4c5366e95b2699e8b18bc75e5f729c5')))
 
     def test_create_insert_serialize_with_tweak(self):
         # Same test as bloom_create_insert_serialize, but we add a nTweak of 100


### PR DESCRIPTION
Previous code was invalid and not tested (_ser_read is not declared in the scope and the name isn't even right), plus self was used in a classmethod before the 'self' variable declaration. Also removed another unused import. 

It's now fixed and tested.

```
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  py35: commands succeeded
  pypy: commands succeeded
SKIPPED:  pypy3: InterpreterNotFound: pypy3
  stats: commands succeeded
  congratulations :)
```