### PR TITLE
Bugfixing and more test coverage for bitcoin/net.py

### DIFF
--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -172,6 +172,7 @@ class Serializer(object):
     @classmethod
     def stream_serialize(cls, obj, f):
         raise NotImplementedError
+
     @classmethod
     def stream_deserialize(cls, f):
         raise NotImplementedError
@@ -184,7 +185,9 @@ class Serializer(object):
 
     @classmethod
     def deserialize(cls, buf):
-        return cls.stream_deserialize(_BytesIO(buf))
+        if isinstance(buf, str) or isinstance(buf, bytes):
+            buf = _BytesIO(buf)
+        return cls.stream_deserialize(buf)
 
 
 class VarIntSerializer(Serializer):
@@ -266,7 +269,8 @@ class uint256VectorSerializer(Serializer):
         return r
 
 
-class intVectorSerialzer(Serializer):
+class intVectorSerializer(Serializer):
+
     @classmethod
     def stream_serialize(cls, ints, f):
         l = len(ints)
@@ -279,7 +283,8 @@ class intVectorSerialzer(Serializer):
         l = VarIntSerializer.stream_deserialize(f)
         ints = []
         for i in range(l):
-            ints.append(struct.unpack(b"<i", ser_read(f, 4)))
+            ints.append(struct.unpack(b"<i", ser_read(f, 4))[0])
+        return ints
 
 
 class VarStringSerializer(Serializer):
@@ -362,7 +367,7 @@ __all__ = (
         'BytesSerializer',
         'VectorSerializer',
         'uint256VectorSerializer',
-        'intVectorSerialzer',
+        'intVectorSerializer',
         'VarStringSerializer',
         'uint256_from_str',
         'uint256_from_compact',

--- a/bitcoin/net.py
+++ b/bitcoin/net.py
@@ -17,6 +17,7 @@ import socket
 from bitcoin.core.serialize import (
         Serializable,
         VarStringSerializer,
+        intVectorSerializer,
         ser_read,
         uint256VectorSerializer,
 )
@@ -42,10 +43,10 @@ class CAddress(Serializable):
         if c.protover >= CADDR_TIME_VERSION and not without_time:
             c.nTime = struct.unpack(b"<I", ser_read(f, 4))[0]
         c.nServices = struct.unpack(b"<Q", ser_read(f, 8))[0]
-        
+
         packedIP = ser_read(f, 16)
 
-        if bytes(packedIP[0:12]) == IPV4_COMPAT: # IPv4 
+        if bytes(packedIP[0:12]) == IPV4_COMPAT: # IPv4
             c.ip = socket.inet_ntop(socket.AF_INET, packedIP[12:16])
         else: #IPv6
             c.ip = socket.inet_ntop(socket.AF_INET6, packedIP)
@@ -53,23 +54,18 @@ class CAddress(Serializable):
         c.port = struct.unpack(b">H", ser_read(f, 2))[0]
         return c
 
-
     def stream_serialize(self, f, without_time=False):
         if self.protover >= CADDR_TIME_VERSION and not without_time:
             f.write(struct.pack(b"<I", self.nTime))
         f.write(struct.pack(b"<Q", self.nServices))
 
-        protocol = socket.AF_INET
         if ":" in self.ip: # determine if address is IPv6
             f.write(socket.inet_pton(socket.AF_INET6, self.ip))
-        else: 
+        else:
             f.write(self.pchReserved)
             f.write(socket.inet_pton(socket.AF_INET, self.ip))
 
         f.write(struct.pack(b">H", self.port))
-
-
-
 
     def __repr__(self):
         return "CAddress(nTime=%d nServices=%i ip=%s port=%i)" % (self.nTime, self.nServices, self.ip, self.port)
@@ -145,10 +141,10 @@ class CUnsignedAlert(Serializable):
         c.nExpiration = struct.unpack(b"<q", ser_read(f,8))[0]
         c.nID = struct.unpack(b"<i", ser_read(f,4))[0]
         c.nCancel = struct.unpack(b"<i", ser_read(f,4))[0]
-        c.setCancel = intVectorSerialzer.deserialize(f)
+        c.setCancel = intVectorSerializer.deserialize(f)
         c.nMinVer = struct.unpack(b"<i", ser_read(f,4))[0]
         c.nMaxVer = struct.unpack(b"<i", ser_read(f,4))[0]
-        c.setSubVer = VarStringSerializer.deserialize(f)
+        c.setSubVer = intVectorSerializer.deserialize(f)
         c.nPriority = struct.unpack(b"<i", ser_read(f,4))[0]
         c.strComment = VarStringSerializer.deserialize(f)
         c.strStatusBar = VarStringSerializer.deserialize(f)
@@ -161,14 +157,14 @@ class CUnsignedAlert(Serializable):
         f.write(struct.pack(b"<q", self.nExpiration))
         f.write(struct.pack(b"<i", self.nID))
         f.write(struct.pack(b"<i", self.nCancel))
-        f.write(ser_int_vector(self.setCancel))
+        f.write(intVectorSerializer.serialize(self.setCancel))
         f.write(struct.pack(b"<i", self.nMinVer))
         f.write(struct.pack(b"<i", self.nMaxVer))
-        f.write(ser_string_vector(self.setSubVer))
+        f.write(intVectorSerializer.serialize(self.setSubVer))
         f.write(struct.pack(b"<i", self.nPriority))
-        f.write(ser_string(self.strComment))
-        f.write(ser_string(self.strStatusBar))
-        f.write(ser_string(self.strReserved))
+        f.write(VarStringSerializer.serialize(self.strComment))
+        f.write(VarStringSerializer.serialize(self.strStatusBar))
+        f.write(VarStringSerializer.serialize(self.strReserved))
 
     def __repr__(self):
         return "CUnsignedAlert(nVersion %d, nRelayUntil %d, nExpiration %d, nID %d, nCancel %d, nMinVer %d, nMaxVer %d, nPriority %d, strComment %s, strStatusBar %s, strReserved %s)" % (self.nVersion, self.nRelayUntil, self.nExpiration, self.nID, self.nCancel, self.nMinVer, self.nMaxVer, self.nPriority, self.strComment, self.strStatusBar, self.strReserved)

--- a/bitcoin/tests/test_bloom.py
+++ b/bitcoin/tests/test_bloom.py
@@ -11,8 +11,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import json
-import os
 import unittest
 
 import bitcoin.core

--- a/bitcoin/tests/test_key.py
+++ b/bitcoin/tests/test_key.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from bitcoin.core.key import *
-from bitcoin.core import x, b2x
+from bitcoin.core import x
 
 class Test_CPubKey(unittest.TestCase):
     def test(self):

--- a/bitcoin/tests/test_net.py
+++ b/bitcoin/tests/test_net.py
@@ -11,9 +11,60 @@
 
 import unittest
 
-from bitcoin.net import CAddress
+from bitcoin.net import CAddress, CAlert, CUnsignedAlert, CInv
 
-class Test_CAddress(unittest.TestCase):
+# Py3 compatibility
+import sys
+
+if sys.version > '3':
+    from io import BytesIO as _BytesIO
+else:
+    from cStringIO import StringIO as _BytesIO
+
+
+class TestUnsignedAlert(unittest.TestCase):
+    def test_serialization(self):
+        alert = CUnsignedAlert()
+        alert.setCancel = [1, 2, 3]
+        alert.strComment = b"Comment"
+        stream = _BytesIO()
+
+        alert.stream_serialize(stream)
+        serialized = _BytesIO(stream.getvalue())
+
+        deserialized = CUnsignedAlert.stream_deserialize(serialized)
+        self.assertEqual(deserialized, alert)
+
+
+class TestCAlert(unittest.TestCase):
+    def test_serialization(self):
+        alert = CAlert()
+        alert.setCancel = [1, 2, 3]
+        alert.strComment = b"Comment"
+        stream = _BytesIO()
+
+        alert.stream_serialize(stream)
+        serialized = _BytesIO(stream.getvalue())
+
+        deserialized = CAlert.stream_deserialize(serialized)
+        self.assertEqual(deserialized, alert)
+
+
+class TestCInv(unittest.TestCase):
+    def test_serialization(self):
+        inv = CInv()
+        inv.type = 123
+        inv.hash = b"0" * 32
+        stream = _BytesIO()
+
+        inv.stream_serialize(stream)
+        serialized = _BytesIO(stream.getvalue())
+
+        deserialized = CInv.stream_deserialize(serialized)
+        self.assertEqual(deserialized, inv)
+
+
+class TestCAddress(unittest.TestCase):
     def test_serializationSimple(self):
         c = CAddress()
         cSerialized = c.serialize()
@@ -29,12 +80,11 @@ class Test_CAddress(unittest.TestCase):
 
         cSerialized = c.serialize()
         cDeserialized = CAddress.deserialize(cSerialized)
-        
+
         self.assertEqual(c, cDeserialized)
-        
+
         cSerializedTwice = cDeserialized.serialize()
         self.assertEqual(cSerialized, cSerializedTwice)
-
 
     def test_serializationIPv6(self):
         c = CAddress()
@@ -44,12 +94,11 @@ class Test_CAddress(unittest.TestCase):
 
         cSerialized = c.serialize()
         cDeserialized = CAddress.deserialize(cSerialized)
-        
+
         self.assertEqual(c, cDeserialized)
-        
+
         cSerializedTwice = cDeserialized.serialize()
         self.assertEqual(cSerialized, cSerializedTwice)
-
 
     def test_serializationDiff(self):
         # Sanity check that the serialization code preserves differences

--- a/bitcoin/tests/test_serialize.py
+++ b/bitcoin/tests/test_serialize.py
@@ -12,7 +12,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import unittest
-import os
 
 from binascii import unhexlify
 


### PR DESCRIPTION
* Improved coverage for bitcoin/net.py to 96%
* Fixed three bugs
  * CUnsignedAlert.deserialize referenced invalid functions
  * intVectorSerializer would always return None when deserializing data
  * Serializer.stream_deserialized can be called with a bytes or str argument but expects a _BytesIO
* Removed unused imports and variables