### PR TITLE
Add license info for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name='python-bitcoinlib',
       long_description=README,
       classifiers=[
           "Programming Language :: Python",
+          "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
       ],
       url='https://github.com/petertodd/python-bitcoinlib',
       keywords='bitcoin',


### PR DESCRIPTION
This adds LICENSE to the dist tarball, and the trove license classification to the uploaded PyPI metadata.