### PR TITLE
Interpret 0x00 as OP_0 instead of b''

### DIFF
--- a/bitcoin/core/script.py
+++ b/bitcoin/core/script.py
@@ -621,7 +621,9 @@ class CScript(bytes):
         PUSHDATA encodings.
         """
         for (opcode, data, sop_idx) in self.raw_iter():
-            if data is not None:
+            if opcode == 0:
+                yield 0
+            elif data is not None:
                 yield data
             else:
                 opcode = CScriptOp(opcode)

--- a/bitcoin/tests/test_script.py
+++ b/bitcoin/tests/test_script.py
@@ -95,7 +95,7 @@ class Test_CScript(unittest.TestCase):
         T('', [])
 
         # standard pushdata
-        T('00', [b''])
+        T('00', [OP_0])
         T('0100', [b'\x00'])
         T('4b' + 'ff'*0x4b, [b'\xff'*0x4b])
 
@@ -108,6 +108,7 @@ class Test_CScript(unittest.TestCase):
         T('4e04000000deadbeef', [x('deadbeef')], False)
 
         # numbers
+        T('00', [0x0])
         T('4f', [OP_1NEGATE])
         T('51', [0x1])
         T('52', [0x2])
@@ -240,7 +241,7 @@ class Test_CScript(unittest.TestCase):
           "CScript([1, x('7ac977d8373df875eceda362298e5d09d4b72b53'), OP_DROP])")
 
         T(CScript(x('0001ff515261ff')),
-          "CScript([x(''), x('ff'), 1, 2, OP_NOP, OP_INVALIDOPCODE])")
+          "CScript([0, x('ff'), 1, 2, OP_NOP, OP_INVALIDOPCODE])")
 
         # truncated scripts
         T(CScript(x('6101')),


### PR DESCRIPTION
python-bitcoinlib currently deserializes the null byte `0x00` or `OP_0` as an empty binary string, `b''`.  I even see that in the tests this behavior may be intentional.  I suggest that it be changed to interpret `0x00` as a small integer, to make it consistent with the other small integers.  People looking for empty data pushes can always use raw_iter.

The reason this matters is that Segregated Witness uses a byte, interpreted as a small integer, as its "witness version".  This byte for V1 witness transactions currently being created is 0x00.  

I want to make this change to save future users looking at segwit transactions some confusion when their transaction is deserialized with a `x('')` instead of `0` for the witness version.