### PR TITLE
Add missing README.md to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE
+include LICENSE README.md


### PR DESCRIPTION
Should resolve an issue that occurs when specifying `python-bitcoinlib==0.6.0` in `install_requires` in `setup.py`:

```
Searching for python-bitcoinlib==0.6.0
Reading https://pypi.python.org/simple/python-bitcoinlib/
Best match: python-bitcoinlib 0.6.0
Downloading https://pypi.python.org/packages/d9/b4/547a82648cab2db3b7622ecb3b19f1c40c03fe810d33bef2695d45b01376/python-bitcoinlib-0.6.0.tar.gz#md5=f4ea5084cc8af552effe1bc0288d258d
Processing python-bitcoinlib-0.6.0.tar.gz
Writing /tmp/easy_install-ovmbcw19/python-bitcoinlib-0.6.0/setup.cfg
Running python-bitcoinlib-0.6.0/setup.py -q bdist_egg --dist-dir /tmp/easy_install-ovmbcw19/python-bitcoinlib-0.6.0/egg-dist-tmp-7k7se_cv
error: [Errno 2] No such file or directory: '/tmp/easy_install-ovmbcw19/python-bitcoinlib-0.6.0/README.md'
```

To verify:

```
from setuptools import setup

setup(
    install_requires=[
		'python-bitcoinlib==[ insert updated version here ]'
    ]
)
```

then:

```
python3 setup.py install
```

I didn't bump the version or anything, let me know if I should do that.