### PR TITLE
Serialize msg_header using CBlockHeader instead of CBlock

### DIFF
--- a/bitcoin/messages.py
+++ b/bitcoin/messages.py
@@ -336,11 +336,11 @@ class msg_headers(MsgSerializable):
     @classmethod
     def msg_deser(cls, f, protover=PROTO_VERSION):
         c = cls()
-        c.headers = VectorSerializer.stream_deserialize(CBlock, f)
+        c.headers = VectorSerializer.stream_deserialize(CBlockHeader, f)
         return c
 
     def msg_ser(self, f):
-        VectorSerializer.stream_serialize(CBlock, self.headers, f)
+        VectorSerializer.stream_serialize(CBlockHeader, self.headers, f)
 
     def __repr__(self):
         return "msg_headers(headers=%s)" % (repr(self.headers))


### PR DESCRIPTION
This resolves an issue I uncovered while updating `pynode` to work with `python-bitcoinlib` 0.7.0. The following usage was previously allowable, because `CBlock` was mutable:

```py
db_block = self.chaindb.getblock(blkhash)
block = copy.copy(db_block)
block.vtx = []
msg.headers.append(block)
```

I [updated it](https://github.com/jgarzik/pynode/pull/19/files#diff-97b3827045a89ffba8170a14179aeb74L373) to the following, which resulted in the type error that this PR fixes:

```py
block = self.chaindb.getblock(blkhash)
msg.headers.append(block.get_header())
```