### PR TITLE
Convert README.md to rst in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,27 @@
 
 from setuptools import setup, find_packages
 import os
+import subprocess
 
 from bitcoin import __version__
 
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'README.md')) as f:
-    README = f.read()
+readme_path = os.path.join(here, 'README.md')
+try:
+    args = 'pandoc', '--from', 'markdown', '--to', 'rst', readme_path
+    readme = subprocess.check_output(args).decode()
+except Exception as error:
+    print('README.md conversion to reStructuredText failed. Error:')
+    print(error)
+    with open(readme_path) as read_file:
+        readme = read_file.read()
 
 requires = []
 
 setup(name='python-bitcoinlib',
       version=__version__,
       description='The Swiss Army Knife of the Bitcoin protocol.',
-      long_description=README,
+      long_description=readme,
       classifiers=[
           "Programming Language :: Python",
           "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",


### PR DESCRIPTION
Currently, the package description [on PyPI](https://pypi.python.org/pypi/python-bitcoinlib/0.7.0) displays the raw markdown text from `README.md`. This occurs because PyPI only accepts reStructuredText for package descriptions. This pull request enables formatted descriptions for future PyPI releases by converting the README to rst.

Pandoc is used for the conversion. If pandoc is not installed, then the markdown README is passed to `long_description`. I've looked into several solutions to the README formatting issue with PyPI and think this is the best. As long as the machine which builds the package to send to PyPI has Pandoc, the PyPI page will be pretty.