### PR TITLE
FakeBitcoinProxy: a mock RPC implementation.

### DIFF
--- a/bitcoin/tests/fakebitcoinproxy.py
+++ b/bitcoin/tests/fakebitcoinproxy.py
@@ -1,0 +1,327 @@
+"""
+`FakeBitcoinProxy` allows for unit testing of code that normally uses bitcoin
+RPC without requiring a running bitcoin node.
+
+`FakeBitcoinProxy` has an interface similar to `bitcoin.rpc.Proxy`, but does not
+connect to a local bitcoin RPC node. Hence, `FakeBitcoinProxy` is similar to a
+mock for the RPC tests.
+
+`FakeBitcoinProxy` does _not_ implement a full bitcoin RPC node. Instead, it
+currently implements only a subset of the available RPC commands. Test setup is
+responsible for populating a `FakeBitcoinProxy` object with reasonable mock
+data.
+
+:author: Bryan Bishop <kanzure@gmail.com>
+"""
+
+import random
+import hashlib
+
+from bitcoin.core import (
+    # bytes to hex (see x)
+    b2x,
+
+    # convert hex string to bytes (see b2x)
+    x,
+
+    # convert little-endian hex string to bytes (see b2lx)
+    lx,
+
+    # convert bytes to little-endian hex string (see lx)
+    b2lx,
+
+    # number of satoshis per bitcoin
+    COIN,
+
+    # a type for a transaction that isn't finished building
+    CMutableTransaction,
+    CMutableTxIn,
+    CMutableTxOut,
+    COutPoint,
+    CTxIn,
+)
+
+from bitcoin.wallet import (
+    # bitcoin address initialized from base58-encoded string
+    CBitcoinAddress,
+
+    # base58-encoded secret key
+    CBitcoinSecret,
+
+    # has a nifty function from_pubkey
+    P2PKHBitcoinAddress,
+)
+
+def make_address_from_passphrase(passphrase, compressed=True, as_str=True):
+    """
+    Create a Bitcoin address from a passphrase. The passphrase is hashed and
+    then used as the secret bytes to construct the CBitcoinSecret.
+    """
+    if not isinstance(passphrase, bytes):
+        passphrase = bytes(passphrase, "utf-8")
+    passphrasehash = hashlib.sha256(passphrase).digest()
+    private_key = CBitcoinSecret.from_secret_bytes(passphrasehash, compressed=compressed)
+    address = P2PKHBitcoinAddress.from_pubkey(private_key.pub)
+    if as_str:
+        return str(address)
+    else:
+        return address
+
+def make_txout(amount=None, address=None, counter=None):
+    """
+    Make a CTxOut object based on the parameters. Otherwise randomly generate a
+    CTxOut to represent a transaction output.
+
+    :param amount: amount in satoshis
+    """
+    passphrase_template = "correct horse battery staple txout {counter}"
+
+    if not counter:
+        counter = random.randrange(0, 2**50)
+
+    if not address:
+        passphrase = passphrase_template.format(counter=counter)
+        address = make_address_from_passphrase(bytes(passphrase, "utf-8"))
+
+    if not amount:
+        maxsatoshis = (21 * 1000 * 1000) * (100 * 1000 * 1000) # 21 million BTC * 100 million satoshi per BTC
+        amount = random.randrange(0, maxsatoshis) # between 0 satoshi and 21 million BTC
+
+    txout = CMutableTxOut(amount, CBitcoinAddress(address).to_scriptPubKey())
+
+    return txout
+
+def make_blocks_from_blockhashes(blockhashes):
+    """
+    Create some block data suitable for FakeBitcoinProxy to consume during
+    instantiation.
+    """
+    blocks = []
+
+    for (height, blockhash) in enumerate(blockhashes):
+        block = {"hash": blockhash, "height": height, "tx": []}
+        if height != 0:
+            block["previousblockhash"] = previousblockhash
+        blocks.append(block)
+        previousblockhash = blockhash
+
+    return blocks
+
+def make_rpc_batch_request_entry(rpc_name, params):
+    """
+    Construct an entry for the list of commands that will be passed as a batch
+    (for `_batch`).
+    """
+    return {
+        "id": "50",
+        "version": "1.1",
+        "method": rpc_name,
+        "params": params,
+    }
+
+class FakeBitcoinProxyException(Exception):
+    """
+    Incorrect usage of fake proxy.
+    """
+    pass
+
+class FakeBitcoinProxy(object):
+    """
+    This is an alternative to using `bitcoin.rpc.Proxy` in tests. This class
+    can store a number of blocks and transactions, which can then be retrieved
+    by calling various "RPC" methods.
+    """
+
+    def __init__(self, blocks=None, transactions=None, getnewaddress_offset=None, getnewaddress_passphrase_template="getnewaddress passphrase template {}", num_fundrawtransaction_inputs=5):
+        """
+        :param getnewaddress_offset: a number to start using and incrementing
+        in template used by getnewaddress.
+        :type getnewaddress_offset: int
+        :param int num_fundrawtransaction_inputs: number of inputs to create
+        during fundrawtransaction.
+        """
+        self.blocks = blocks or {}
+        self.transactions = transactions or {}
+
+        if getnewaddress_offset == None:
+            self._getnewaddress_offset = 0
+        else:
+            self._getnewaddress_offset = getnewaddress_offset
+
+        self._getnewaddress_passphrase_template = getnewaddress_passphrase_template
+        self._num_fundrawtransaction_inputs = num_fundrawtransaction_inputs
+        self.populate_blocks_with_blockheights()
+
+    def _call(self, rpc_method_name, *args, **kwargs):
+        """
+        This represents a "raw" RPC call, which has output that
+        python-bitcoinlib does not parse.
+        """
+        method = getattr(self, rpc_method_name)
+        return method(*args, **kwargs)
+
+    def populate_blocks_with_blockheights(self):
+        """
+        Helper method to correctly apply "height" on all blocks.
+        """
+        for (height, block) in enumerate(self.blocks):
+            block["height"] = height
+
+    def getblock(self, blockhash, *args, **kwargs):
+        """
+        :param blockhash: hash of the block to retrieve data for
+        :raise IndexError: invalid blockhash
+        """
+
+        # Note that the actual "getblock" bitcoind RPC call from
+        # python-bitcoinlib returns a CBlock object, not a dictionary.
+
+        if isinstance(blockhash, bytes):
+            blockhash = b2lx(blockhash)
+
+        for block in self.blocks:
+            if block["hash"] == blockhash:
+                return block
+
+        raise IndexError("no block found for blockhash {}".format(blockhash))
+
+    def getblockhash(self, blockheight):
+        """
+        Get block by blockheight.
+
+        :type blockheight: int
+        :rtype: dict
+        """
+        for block in self.blocks:
+            if block["height"] == int(blockheight):
+                return block["hash"]
+
+    def getblockcount(self):
+        """
+        Return the total number of blocks. When there is only one block in the
+        blockchain, this function will return zero.
+
+        :rtype: int
+        """
+        return len(self.blocks) - 1
+
+    def getrawtransaction(self, txid, *args, **kwargs):
+        """
+        Get parsed transaction.
+
+        :type txid: bytes or str
+        :rtype: dict
+        """
+        if isinstance(txid, bytes):
+            txid = b2lx(txid)
+        return self.transactions[txid]
+
+    def getnewaddress(self):
+        """
+        Construct a new address based on a passphrase template. As more
+        addresses are generated, the template value goes up.
+        """
+        passphrase = self._getnewaddress_passphrase_template.format(self._getnewaddress_offset)
+        address = make_address_from_passphrase(bytes(passphrase, "utf-8"))
+        self._getnewaddress_offset += 1
+        return CBitcoinAddress(address)
+
+    def importaddress(self, *args, **kwargs):
+        """
+        Completely unrealistic fake version of importaddress.
+        """
+        return True
+
+    # This was implemented a long time ago and it's possible that this does not
+    # match the current behavior of fundrawtransaction.
+    def fundrawtransaction(self, given_transaction, *args, **kwargs):
+        """
+        Make up some inputs for the given transaction.
+        """
+        # just use any txid here
+        vintxid = lx("99264749804159db1e342a0c8aa3279f6ef4031872051a1e52fb302e51061bef")
+
+        if isinstance(given_transaction, str):
+            given_bytes = x(given_transaction)
+        elif isinstance(given_transaction, CMutableTransaction):
+            given_bytes = given_transaction.serialize()
+        else:
+            raise FakeBitcoinProxyException("Wrong type passed to fundrawtransaction.")
+
+        # this is also a clever way to not cause a side-effect in this function
+        transaction = CMutableTransaction.deserialize(given_bytes)
+
+        for vout_counter in range(0, self._num_fundrawtransaction_inputs):
+            txin = CMutableTxIn(COutPoint(vintxid, vout_counter))
+            transaction.vin.append(txin)
+
+        # also allocate a single output (for change)
+        txout = make_txout()
+        transaction.vout.append(txout)
+
+        transaction_hex = b2x(transaction.serialize())
+
+        return {"hex": transaction_hex, "fee": 5000000}
+
+    def signrawtransaction(self, given_transaction):
+        """
+        This method does not actually sign the transaction, but it does return
+        a transaction based on the given transaction.
+        """
+        if isinstance(given_transaction, str):
+            given_bytes = x(given_transaction)
+        elif isinstance(given_transaction, CMutableTransaction):
+            given_bytes = given_transaction.serialize()
+        else:
+            raise FakeBitcoinProxyException("Wrong type passed to signrawtransaction.")
+
+        transaction = CMutableTransaction.deserialize(given_bytes)
+        transaction_hex = b2x(transaction.serialize())
+        return {"hex": transaction_hex}
+
+    def sendrawtransaction(self, given_transaction):
+        """
+        Pretend to broadcast and relay the transaction. Return the txid of the
+        given transaction.
+        """
+        if isinstance(given_transaction, str):
+            given_bytes = x(given_transaction)
+        elif isinstance(given_transaction, CMutableTransaction):
+            given_bytes = given_transaction.serialize()
+        else:
+            raise FakeBitcoinProxyException("Wrong type passed to sendrawtransaction.")
+        transaction = CMutableTransaction.deserialize(given_bytes)
+        return b2lx(transaction.GetHash())
+
+    def _batch(self, batch_request_entries):
+        """
+        Process a bunch of requests all at once. This mimics the _batch RPC
+        feature found in python-bitcoinlib and bitcoind RPC.
+        """
+        necessary_keys = ["id", "version", "method", "params"]
+
+        results = []
+
+        for (idx, request) in enumerate(batch_request_entries):
+            error = None
+            result = None
+
+            # assert presence of important details
+            for necessary_key in necessary_keys:
+                if not necessary_key in request.keys():
+                    raise FakeBitcoinProxyException("Missing necessary key {} for _batch request number {}".format(necessary_key, idx))
+
+            if isinstance(request["params"], list):
+                method = getattr(self, request["method"])
+                result = method(*request["params"])
+            else:
+                # matches error message received through python-bitcoinrpc
+                error = {"message": "Params must be an array", "code": -32600}
+
+            results.append({
+                "error": error,
+                "id": request["id"],
+                "result": result,
+            })
+
+        return results

--- a/bitcoin/tests/test_fakebitcoinproxy.py
+++ b/bitcoin/tests/test_fakebitcoinproxy.py
@@ -1,0 +1,420 @@
+"""
+:author: Bryan Bishop <kanzure@gmail.com>
+"""
+
+import unittest
+import random
+from copy import copy
+
+from bitcoin.core import (
+    # bytes to hex (see x)
+    b2x,
+
+    # convert hex string to bytes (see b2x)
+    x,
+
+    # convert little-endian hex string to bytes (see b2lx)
+    lx,
+
+    # convert bytes to little-endian hex string (see lx)
+    b2lx,
+
+    # number of satoshis per bitcoin
+    COIN,
+
+    # a type for a transaction that isn't finished building
+    CMutableTransaction,
+    CMutableTxIn,
+    CMutableTxOut,
+    COutPoint,
+    CTxIn,
+)
+
+from bitcoin.wallet import (
+    # has a nifty function from_pubkey
+    P2PKHBitcoinAddress,
+)
+
+from fakebitcoinproxy import (
+    FakeBitcoinProxy,
+    make_txout,
+    make_blocks_from_blockhashes,
+    make_rpc_batch_request_entry,
+
+    # TODO: import and test with FakeBitcoinProxyException
+)
+
+class FakeBitcoinProxyTestCase(unittest.TestCase):
+    def test_constructor(self):
+        FakeBitcoinProxy()
+
+    def test_constructor_accepts_blocks(self):
+        blockhash0 = "blockhash0"
+        blockhash1 = "blockhash1"
+
+        blocks = [
+            {"hash": blockhash0},
+            {"hash": blockhash1},
+        ]
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+
+        self.assertNotEqual(proxy.blocks, {})
+        self.assertTrue(proxy.blocks is blocks)
+
+    def test_getblock_with_string(self):
+        blockhash0 = "blockhash0"
+        blockhash1 = "blockhash1"
+
+        blocks = [
+            {"hash": blockhash0},
+            {"hash": blockhash1},
+        ]
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+        result = proxy.getblock(blockhash0)
+
+        self.assertEqual(type(result), dict)
+
+        # should have a height now
+        self.assertTrue("height" in result.keys())
+        self.assertEqual(result["height"], 0)
+
+    def test_blockheight_extensively(self):
+        blockhashes = ["blockhash{}".format(x) for x in range(0, 10)]
+
+        blocks = []
+        for blockhash in blockhashes:
+            blocks.append({"hash": blockhash})
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+
+        for (expected_height, blockhash) in enumerate(blockhashes):
+            blockdata = proxy.getblock(blockhash)
+            self.assertEqual(blockdata["height"], expected_height)
+
+    def test_getblock_with_bytes(self):
+        blockhash0 = "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936301"
+
+        blocks = [
+            {"hash": blockhash0},
+        ]
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+        result = proxy.getblock(lx(blockhash0))
+
+        self.assertEqual(type(result), dict)
+
+    def test_getblock_returns_transaction_data(self):
+        blockhash0 = "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936302"
+
+        transaction_txids = ["foo", "bar"]
+
+        blocks = [
+            {"hash": blockhash0, "tx": transaction_txids},
+        ]
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+        result = proxy.getblock(blockhash0)
+
+        self.assertTrue("tx" in result.keys())
+        self.assertEqual(type(result["tx"]), list)
+        self.assertEqual(result["tx"], transaction_txids)
+
+    def test_getblockhash_zero(self):
+        blockhash0 = "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936302"
+
+        blocks = [
+            {"hash": blockhash0},
+        ]
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+
+        blockhash_result = proxy.getblockhash(0)
+
+        self.assertEqual(blockhash_result, blockhash0)
+
+    def test_getblockhash_many(self):
+        blockhashes = [
+            "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936302",
+            "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936303",
+            "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936304",
+            "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936305",
+        ]
+
+        blocks = make_blocks_from_blockhashes(blockhashes)
+        proxy = FakeBitcoinProxy(blocks=blocks)
+
+        for (height, expected_blockhash) in enumerate(blockhashes):
+            blockhash_result = proxy.getblockhash(height)
+            self.assertEqual(blockhash_result, expected_blockhash)
+
+    def test_getblockcount_zero(self):
+        blocks = []
+        proxy = FakeBitcoinProxy(blocks=blocks)
+        count = proxy.getblockcount()
+        self.assertEqual(count, len(blocks) - 1)
+
+    def test_getblockcount_many(self):
+        blockhash0 = "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea64936301"
+        blockhash1 = "0000b9fc70e9a8bb863a8c37f0f3d10d4d3e99e0e94bd42b35f0fdbb497399eb"
+
+        blocks = [
+            {"hash": blockhash0},
+            {"hash": blockhash1, "previousblockhash": blockhash0},
+        ]
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+        count = proxy.getblockcount()
+        self.assertEqual(count, len(blocks) - 1)
+
+    def test_getrawtransaction(self):
+        txids = [
+            "b9e3b3366b31136bd262c64ff6e4c29918a457840c5f53cbeeeefa41ca3b7005",
+            "21886e5c02049751acea9d462359d68910bef938d9a58288c961d18b6e50daef",
+            "b2d0cc6840be86516ce79ed7249bfd09f95923cc27784c2fa0dd910bfdb03173",
+            "eacb81d11a539047af73b5d810d3683af3b1171e683dcbfcfb2819286d762c0c",
+            "eee72e928403fea7bca29f366483c3e0ab629ac5dce384a0f541aacf6f810d30",
+        ]
+
+        txdefault = {"tx": "", "confirmations": 0}
+
+        transactions = dict([(txid, copy(txdefault)) for txid in txids])
+
+        # just making sure...
+        self.assertTrue(transactions[txids[0]] is not transactions[txids[1]])
+
+        proxy = FakeBitcoinProxy(transactions=transactions)
+
+        for txid in txids:
+            txdata = proxy.getrawtransaction(txid)
+
+            self.assertEqual(type(txdata), dict)
+            self.assertTrue("tx" in txdata.keys())
+            self.assertEqual(type(txdata["tx"]), str)
+            self.assertEqual(txdata["tx"], "")
+            self.assertTrue("confirmations" in txdata.keys())
+            self.assertEqual(txdata["confirmations"], 0)
+
+    def test_getnewaddress_returns_different_addresses(self):
+        num_addresses = random.randint(10, 100)
+        addresses = set()
+
+        proxy = FakeBitcoinProxy()
+
+        for each in range(num_addresses):
+            address = proxy.getnewaddress()
+            addresses.add(str(address))
+
+        self.assertEqual(len(addresses), num_addresses)
+
+    def test_getnewaddress_returns_cbitcoinaddress(self):
+        proxy = FakeBitcoinProxy()
+        address = proxy.getnewaddress()
+        self.assertEqual(type(address), P2PKHBitcoinAddress)
+
+    def test_importaddress(self):
+        proxy = FakeBitcoinProxy()
+        proxy.importaddress("foo")
+
+    def test_importaddress_with_parameters(self):
+        proxy = FakeBitcoinProxy()
+        address = "some_address"
+        label = ""
+        rescan = False
+        proxy.importaddress(address, label, rescan)
+
+    def test_fundrawtransaction(self):
+        unfunded_transaction = CMutableTransaction([], [make_txout() for x in range(0, 5)])
+        proxy = FakeBitcoinProxy()
+
+        funded_transaction_hex = proxy.fundrawtransaction(unfunded_transaction)["hex"]
+        funded_transaction = CMutableTransaction.deserialize(x(funded_transaction_hex))
+
+        self.assertTrue(unfunded_transaction is not funded_transaction)
+        self.assertEqual(type(funded_transaction), type(unfunded_transaction))
+        self.assertNotEqual(len(funded_transaction.vin), 0)
+        self.assertTrue(len(funded_transaction.vin) > len(unfunded_transaction.vin))
+        self.assertEqual(type(funded_transaction.vin[0]), CTxIn)
+
+    def test_fundrawtransaction_hex_hash(self):
+        unfunded_transaction = CMutableTransaction([], [make_txout() for x in range(0, 5)])
+        proxy = FakeBitcoinProxy()
+
+        funded_transaction_hex = proxy.fundrawtransaction(b2x(unfunded_transaction.serialize()))["hex"]
+        funded_transaction = CMutableTransaction.deserialize(x(funded_transaction_hex))
+
+        self.assertTrue(unfunded_transaction is not funded_transaction)
+        self.assertEqual(type(funded_transaction), type(unfunded_transaction))
+        self.assertNotEqual(len(funded_transaction.vin), 0)
+        self.assertTrue(len(funded_transaction.vin) > len(unfunded_transaction.vin))
+        self.assertEqual(type(funded_transaction.vin[0]), CTxIn)
+
+    def test_fundrawtransaction_adds_output(self):
+        num_outputs = 5
+        unfunded_transaction = CMutableTransaction([], [make_txout() for x in range(0, num_outputs)])
+        proxy = FakeBitcoinProxy()
+
+        funded_transaction_hex = proxy.fundrawtransaction(b2x(unfunded_transaction.serialize()))["hex"]
+        funded_transaction = CMutableTransaction.deserialize(x(funded_transaction_hex))
+
+        self.assertTrue(len(funded_transaction.vout) > num_outputs)
+        self.assertEqual(len(funded_transaction.vout), num_outputs + 1)
+
+    def test_signrawtransaction(self):
+        num_outputs = 5
+        given_transaction = CMutableTransaction([], [make_txout() for x in range(0, num_outputs)])
+        proxy = FakeBitcoinProxy()
+
+        result = proxy.signrawtransaction(given_transaction)
+
+        self.assertEqual(type(result), dict)
+        self.assertTrue("hex" in result.keys())
+
+        result_transaction_hex = result["hex"]
+        result_transaction = CMutableTransaction.deserialize(x(result_transaction_hex))
+
+        self.assertTrue(result_transaction is not given_transaction)
+        self.assertTrue(result_transaction.vin is not given_transaction.vin)
+        self.assertTrue(result_transaction.vout is not given_transaction.vout)
+        self.assertEqual(len(result_transaction.vout), len(given_transaction.vout))
+        self.assertEqual(result_transaction.vout[0].scriptPubKey, given_transaction.vout[0].scriptPubKey)
+
+    def test_sendrawtransaction(self):
+        num_outputs = 5
+        given_transaction = CMutableTransaction([], [make_txout() for x in range(0, num_outputs)])
+        expected_txid = b2lx(given_transaction.GetHash())
+        given_transaction_hex = b2x(given_transaction.serialize())
+        proxy = FakeBitcoinProxy()
+        resulting_txid = proxy.sendrawtransaction(given_transaction_hex)
+        self.assertEqual(resulting_txid, expected_txid)
+
+    def test__batch_empty_list_input(self):
+        requests = []
+        self.assertEqual(len(requests), 0) # must be empty for test
+        proxy = FakeBitcoinProxy()
+        results = proxy._batch(requests)
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), 0)
+
+    def test__batch_raises_when_no_params(self):
+        proxy = FakeBitcoinProxy()
+        with self.assertRaises(TypeError):
+            proxy._batch()
+
+    def test__batch_same_count_results_as_requests(self):
+        proxy = FakeBitcoinProxy()
+        request = make_rpc_batch_request_entry("getblockcount", [])
+        requests = [request]
+        results = proxy._batch(requests)
+        self.assertEqual(len(requests), len(results))
+
+    def test__batch_gives_reasonable_getblockcount_result(self):
+        proxy = FakeBitcoinProxy()
+        request = make_rpc_batch_request_entry("getblockcount", [])
+        requests = [request]
+        results = proxy._batch(requests)
+        self.assertEqual(results[0]["result"], -1)
+
+    def test__batch_result_keys(self):
+        expected_keys = ["error", "id", "result"]
+        proxy = FakeBitcoinProxy()
+        request = make_rpc_batch_request_entry("getblockcount", [])
+        requests = [request]
+        results = proxy._batch(requests)
+        result = results[0]
+        self.assertTrue(all([expected_key in result.keys() for expected_key in expected_keys]))
+
+    def test__batch_result_error_is_none(self):
+        proxy = FakeBitcoinProxy()
+        request = make_rpc_batch_request_entry("getblockcount", [])
+        requests = [request]
+        results = proxy._batch(requests)
+        result = results[0]
+        self.assertEqual(result["error"], None)
+
+    def test__batch_returns_error_when_given_invalid_params(self):
+        params = 1
+        proxy = FakeBitcoinProxy()
+        request = make_rpc_batch_request_entry("getblockcount", params)
+        requests = [request]
+        results = proxy._batch(requests)
+        result = results[0]
+        self.assertEqual(type(result), dict)
+        self.assertIn("error", result.keys())
+        self.assertIn("id", result.keys())
+        self.assertIn("result", result.keys())
+        self.assertEqual(result["result"], None)
+        self.assertEqual(type(result["error"]), dict)
+        self.assertIn("message", result["error"].keys())
+        self.assertIn("code", result["error"].keys())
+        self.assertEqual(result["error"]["message"], "Params must be an array")
+
+    def test__batch_getblockhash_many(self):
+        block_count = 100
+        blocks = []
+
+        previous_blockhash = None
+        for counter in range(0, block_count):
+            blockhash = "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea649{}".format(counter)
+            block_data = {
+                "hash": blockhash,
+            }
+
+            if previous_blockhash:
+                block_data["previous_blockhash"] = previous_blockhash
+
+            blocks.append(block_data)
+            previous_blockhash = blockhash
+
+        proxy = FakeBitcoinProxy(blocks=blocks)
+        count = proxy.getblockcount()
+        self.assertEqual(count, len(blocks) - 1)
+
+        requests = []
+        for counter in range(0, count + 1): # from 0 to len(blocks)
+            request = make_rpc_batch_request_entry("getblockhash", [counter])
+            requests.append(request)
+
+        results = proxy._batch(requests)
+
+        self.assertEqual(type(results), list)
+        self.assertEqual(len(results), len(requests))
+
+        for (counter, result) in enumerate(results):
+            self.assertEqual(result["error"], None)
+
+            expected_blockhash = "00008c0c84aee66413f1e8ff95fdca5e8ebf35c94b090290077cdcea649{}".format(counter)
+            self.assertEqual(result["result"], expected_blockhash)
+
+    def test_make_blocks_from_blockhashes(self):
+        blockhashes = ["blah{}".format(x) for x in range(0, 25)]
+        blocks = make_blocks_from_blockhashes(blockhashes)
+
+        self.assertEqual(type(blocks), list)
+        self.assertEqual(len(blocks), len(blockhashes))
+        self.assertEqual(type(blocks[0]), dict)
+        self.assertTrue(all(["hash" in block.keys() for block in blocks]))
+        self.assertTrue(all(["height" in block.keys() for block in blocks]))
+        self.assertTrue(all(["tx" in block.keys() for block in blocks]))
+        self.assertNotIn("previousblockhash", blocks[0].keys())
+        self.assertTrue(all(["previousblockhash" in block.keys() for block in blocks[1:]]))
+        self.assertEqual(blocks[-1]["previousblockhash"], blocks[-2]["hash"])
+        self.assertEqual(sorted([block["hash"] for block in blocks]), sorted(blockhashes))
+
+    def test_make_blocks_from_blockhashes_empty(self):
+        blockhashes = []
+        blocks = make_blocks_from_blockhashes(blockhashes)
+        self.assertEqual(type(blocks), list)
+        self.assertEqual(len(blocks), len(blockhashes))
+
+        # Just in case for some reason the function ever appends to the given
+        # list (incorrectly)..
+        self.assertEqual(len(blockhashes), 0)
+        self.assertEqual(len(blocks), 0)
+
+        # and because paranoia
+        self.assertTrue(blockhashes is not blocks)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
FakeBitcoinProxy provides an interface similar to the bitcoin.rpc.Proxy API. Downstream applications interested in unit testing can use FakeBitcoinProxy as an alternative to elaborate Proxy mocks. This interface returns similar values as Proxy and is intended to have similar behavior.

Unit tests are provided and they are passing.

We've been using FakeBitcoinProxy since 2015 to test many different bitcoin applications, which have also been tested against bitcoin nodes running on regtest, testnet and mainnet. Specifically, we pass in FakeBitcoinProxy instead of a bitcoin connection and we get back the same behavior in these different environments using the same interface.

Ideally, this contribution would also include tests to show parity between Proxy and FakeBitcoinProxy, even against active bitcoind nodes, but given extensive usage in multiple environments it seems like less of a priority right now.

An interesting future direction for this would be to load test blockchain data from bitcoind regtest files, and then load that up for testing. I have some tools for handcrafting regtest reorg scenarios using FakeBitcoinProxy but I think it would be better to load from file and do less handcrafting.