### PR TITLE
Make it possible to explicitly close RPC connection

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -192,7 +192,6 @@ class BaseProxy(object):
         self.__conn = httplib.HTTPConnection(self.__url.hostname, port=port,
                                              timeout=timeout)
 
-
     def _call(self, service_name, *args):
         self.__id_count += 1
 
@@ -214,7 +213,6 @@ class BaseProxy(object):
                 'code': -343, 'message': 'missing JSON-RPC result'})
         else:
             return response['result']
-
 
     def _batch(self, rpc_call_list):
         postdata = json.dumps(list(rpc_call_list))

--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -233,6 +233,10 @@ class BaseProxy(object):
         return json.loads(http_response.read().decode('utf8'),
                           parse_float=decimal.Decimal)
 
+    def close(self):
+        if self.__conn is not None:
+            self.__conn.close()
+
     def __del__(self):
         if self.__conn is not None:
             self.__conn.close()


### PR DESCRIPTION
So far it is not possible to close a connection. you need to hope that GC does it or access `__connection` over the `__dict__` variable.

This PR let the proxy expose a proper `close()` function.