### PR TITLE
Add the data subdir from the tests within the pypi tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE README.md
+graft bitcoin/tests/data/


### PR DESCRIPTION
Currently the .json files from the data subdir are not included within the pypi tarball, thus making the tests fail when invoking the test suite from the pypi fetched unzipped tarball.