### PR TITLE
Fix struct.unpack receiving an integer instead of a byte

### DIFF
--- a/bitcoin/core/script.py
+++ b/bitcoin/core/script.py
@@ -680,7 +680,7 @@ class CScript(bytes):
     def is_witness_scriptpubkey(self):
         """Returns true if this is a scriptpubkey signaling segregated witness
         data. """
-        return 3 <= len(self) <= 42 and CScriptOp(struct.unpack('<b',self[0])[0]).is_small_int()
+        return 3 <= len(self) <= 42 and CScriptOp(struct.unpack('<b',self[0:1])[0]).is_small_int()
 
     def witness_version(self):
         """Returns the witness version on [0,16]. """


### PR DESCRIPTION
Fix struct.unpack receiving an integer instead of a byte. 

Before I was receiving this error
```
  File "/python-bitcoinlib/venv/lib/python3.6/site-packages/python_bitcoinlib-0.9.0-py3.6.egg/bitcoin/core/script.py", line 684, in is_witness_scriptpubkey
    return 3 <= len(self) <= 42 and CScriptOp(struct.unpack('<b',self[0])[0]).is_small_int()
TypeError: a bytes-like object is required, not 'int'
```

Solved by getting the byte with self[0:1]. A bytearray of length 1 that is accepted by unpack.
Check https://stackoverflow.com/q/29299136/