### PR TITLE
Fix string serializer in python3. Expects bytes, not str.

### DIFF
--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -298,7 +298,7 @@ class VarStringSerializer(Serializer):
     def stream_serialize(cls, s, f):
         l = len(s)
         VarIntSerializer.stream_serialize(l, f)
-        f.write(s)
+        f.write(s.encode())
 
     @classmethod
     def stream_deserialize(cls, f):


### PR DESCRIPTION
The `stream_serialize` method for `VarStringSerializer` uses the `write()` function which expects `bytes` in python3, not `str`.