### PR TITLE
Enable different currency parameters generically

### DIFF
--- a/bitcoin/__init__.py
+++ b/bitcoin/__init__.py
@@ -61,7 +61,7 @@ bitcoin.core.params correctly too.
 #params = bitcoin.core.coreparams = MainParams()
 params = MainParams()
 
-def SelectParams(name):
+def SelectParams(name, generic_params_object=None):
     """Select the chain parameters to use
 
     name is one of 'mainnet', 'testnet', or 'regtest'
@@ -69,12 +69,22 @@ def SelectParams(name):
     Default chain is 'mainnet'
     """
     global params
-    bitcoin.core._SelectCoreParams(name)
+    bitcoin.core._SelectCoreParams(name, generic_params_object)
     if name == 'mainnet':
         params = bitcoin.core.coreparams = MainParams()
     elif name == 'testnet':
         params = bitcoin.core.coreparams = TestNetParams()
     elif name == 'regtest':
         params = bitcoin.core.coreparams = RegTestParams()
+    elif generic_params_object:
+        params = bitcoin.core.coreparams = generic_params_object
     else:
         raise ValueError('Unknown chain %r' % name)
+
+
+class GenericParams(bitcoin.core.CoreChainParams):
+    MESSAGE_START = b''
+    DEFAULT_PORT = None
+    RPC_PORT = None
+    DNS_SEEDS = ()
+    BASE58_PREFIXES = {}

--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -761,7 +761,7 @@ class CoreRegTestParams(CoreTestNetParams):
 """Master global setting for what core chain params we're using"""
 coreparams = CoreMainParams()
 
-def _SelectCoreParams(name):
+def _SelectCoreParams(name, generic_params_object=None):
     """Select the core chain parameters to use
 
     Don't use this directly, use bitcoin.SelectParams() instead so both
@@ -774,6 +774,8 @@ def _SelectCoreParams(name):
         coreparams = CoreTestNetParams()
     elif name == 'regtest':
         coreparams = CoreRegTestParams()
+    elif generic_params_object:
+        coreparams = generic_params_object
     else:
         raise ValueError('Unknown chain %r' % name)
 

--- a/bitcoin/tests/test_params.py
+++ b/bitcoin/tests/test_params.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+import bitcoin
+from bitcoin import GenericParams, MainParams, SelectParams
+from bitcoin.core import CoreMainParams
+
+
+class TestGenericParamsObject(TestCase):
+
+    def tearDown(self):
+        SelectParams('mainnet')
+
+    def test_generic_params_object_in_select_params(self):
+        self.assertEqual(bitcoin.params.MESSAGE_START, MainParams.MESSAGE_START, b'\xf9\xbe\xb4\xd9')
+        self.assertEqual(bitcoin.params.MAX_MONEY, CoreMainParams.MAX_MONEY, 21*10**14)
+
+        params_obj = GenericParams()
+        params_obj.MESSAGE_START = b'test'
+        params_obj.MAX_MONEY = 1500100900
+
+        SelectParams(name='test', generic_params_object=params_obj)
+
+        self.assertEqual(bitcoin.params.MESSAGE_START, params_obj.MESSAGE_START, b'test')
+        self.assertEqual(bitcoin.params.MAX_MONEY, params_obj.MAX_MONEY, 1500100900)


### PR DESCRIPTION
**Context:**
It appeared that [python-bitcoinlib](https://github.com/petertodd/python-bitcoinlib) is a bit limited in the meaning of supporting different currency networks than Bitcoin, Bitcoin Testnet and Regtest. Although with just a little ammendment it can easily be expanded for various bitcoin based currencies.
**Solution:**
Introduced new class *GenericParams* which is unnecessary to call but enables to work on different currency networks.
**Usage example:**
Let say we would like to have a Litecoin currency, which has different message prefix or max_money value than Bitcoin, so we are going to create a GenericParams object with correct Litecoin data and pass as an argument to SelectParams.