### PR TITLE
New method that constructs coinbase transactions

### DIFF
--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -409,7 +409,7 @@ class CTransaction(ImmutableSerializable):
         """Create a coinbase transaction
 
         blockHeight is the new blockheight. reward is the sum of all rewards that
-        will be collected by the miner, in satoshis. outscript is the output script.
+        will be collected by the miner, in bitcoins. outscript is the output script.
         """
         return CTransaction(
             vin = [CTxIn(scriptSig=CScript([blockHeight.to_bytes(4,'little'), x('01')]))],

--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -404,6 +404,18 @@ class CTransaction(ImmutableSerializable):
         object.__setattr__(self, 'vout', tuple(CTxOut.from_txout(txout) for txout in vout))
         object.__setattr__(self, 'wit', CTxWitness.from_txwitness(witness))
 
+    @staticmethod
+    def createCoinbaseTransaction(blockHeight, reward, outscript):
+        """Create a coinbase transaction
+
+        blockHeight is the new blockheight. reward is the sum of all rewards that
+        will be collected by the miner, in satoshis. outscript is the output script.
+        """
+        return CTransaction(
+            vin = [CTxIn(scriptSig=CScript([blockHeight.to_bytes(4,'little'), x('01')]))],
+            vout = [CTxOut(reward, outscript)]
+        )
+
     @classmethod
     def stream_deserialize(cls, f):
         """Deserialize transaction

--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -411,8 +411,10 @@ class CTransaction(ImmutableSerializable):
         blockHeight is the new blockheight. reward is the sum of all rewards that
         will be collected by the miner, in bitcoins. outscript is the output script.
         """
+        byteLength = int(blockHeight).bit_length()/8
+        byteLength += (byteLength % 1 != 0) # round up
         return CTransaction(
-            vin = [CTxIn(scriptSig=CScript([blockHeight.to_bytes(4,'little'), x('01')]))],
+            vin = [CTxIn(scriptSig=CScript([blockHeight.to_bytes(int(byteLength),'little'), x('01')]))],
             vout = [CTxOut(reward, outscript)]
         )
 


### PR DESCRIPTION
This new method, `createCoinbaseTransaction`, creates a `CTransaction` that conforms to the standard coinbase transaction.