### PR TITLE
wallet: Treat any key with a suffix as compressed

### DIFF
--- a/bitcoin/wallet.py
+++ b/bitcoin/wallet.py
@@ -250,7 +250,7 @@ class CBitcoinSecret(bitcoin.base58.CBase58Data, CKey):
             raise CBitcoinSecretError('Not a base58-encoded secret key: got nVersion=%d; expected nVersion=%d' % \
                                       (self.nVersion, bitcoin.params.BASE58_PREFIXES['SECRET_KEY']))
 
-        CKey.__init__(self, self[0:32], len(self) > 32 and _bord(self[32]) == 1)
+        CKey.__init__(self, self[0:32], len(self) > 32)
 
 
 __all__ = (


### PR DESCRIPTION
As more suffix values (e.g. bech32, etc) may be added, the assumption that suffix must be 1 for compressed keys may break.

See BIP 178 (under review [here](https://github.com/bitcoin/bips/pull/673)): https://github.com/kallewoof/bips/blob/bip-typed-wif/bip-0178.mediawiki