### PR TITLE
add comment on an argument of getblock rpc

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -449,6 +449,9 @@ class Proxy(BaseProxy):
             raise TypeError('%s.getblock(): block_hash must be bytes; got %r instance' %
                     (self.__class__.__name__, block_hash.__class__))
         try:
+            # With this change ( https://github.com/bitcoin/bitcoin/commit/96c850c20913b191cff9f66fedbb68812b1a41ea#diff-a0c8f511d90e83aa9b5857e819ced344 ),
+            # bitcoin core's rpc takes 0/1/2 instead of true/false as the 2nd argument which specifies verbosity, since v0.15.0.
+            # The change above is backward-compatible so far; the old "false" is taken as the new "0".
             r = self._call('getblock', block_hash, False)
         except InvalidAddressOrKeyError as ex:
             raise IndexError('%s.getblock(): %s (%d)' %


### PR DESCRIPTION
I found this while I was looking around the code. "true/false" argument is no longer documented in bitcoin core's rpc, This comment might be helpful for those who look this in detail.

We could change the argument to be 0 instead of false, however, it would break if someone is using bitcoin-core before v0.15.0.