### PR TITLE
Fix python 27 incompatibility by defining FileNotFoundError

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -42,6 +42,11 @@ try:
 except ImportError:
     import urlparse
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 import bitcoin
 from bitcoin.core import COIN, x, lx, b2lx, CBlock, CBlockHeader, CTransaction, COutPoint, CTxOut
 from bitcoin.core.script import CScript

--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -42,10 +42,12 @@ try:
 except ImportError:
     import urlparse
 
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
+# needed for python2 compatibility
+if sys.version < '3':
+    try:
+        FileNotFoundError
+    except NameError:
+        FileNotFoundError = IOError
 
 import bitcoin
 from bitcoin.core import COIN, x, lx, b2lx, CBlock, CBlockHeader, CTransaction, COutPoint, CTxOut


### PR DESCRIPTION
This small pul requests fixes a compatibility with python27 by by defining FileNotFoundError.