### PR TITLE
Add simnet params

### DIFF
--- a/bitcoin/__init__.py
+++ b/bitcoin/__init__.py
@@ -53,6 +53,15 @@ class RegTestParams(bitcoin.core.CoreRegTestParams):
                        'SCRIPT_ADDR':196,
                        'SECRET_KEY' :239}
 
+class SimNetParams(bitcoin.core.CoreSimNetParams):
+    MESSAGE_START = b'\xfa\xbf\xb5\xda'
+    DEFAULT_PORT = 18555
+    RPC_PORT = 18554
+    DNS_SEEDS = ()
+    BASE58_PREFIXES = {'PUBKEY_ADDR':63,
+                       'SCRIPT_ADDR':123,
+                       'SECRET_KEY' :100}
+
 """Master global setting for what chain params we're using.
 
 However, don't set this directly, use SelectParams() instead so as to set the
@@ -76,5 +85,7 @@ def SelectParams(name):
         params = bitcoin.core.coreparams = TestNetParams()
     elif name == 'regtest':
         params = bitcoin.core.coreparams = RegTestParams()
+    elif name == 'simnet':
+        params = bitcoin.core.coreparams = SimNetParams()
     else:
         raise ValueError('Unknown chain %r' % name)

--- a/bitcoin/core/__init__.py
+++ b/bitcoin/core/__init__.py
@@ -758,6 +758,13 @@ class CoreRegTestParams(CoreTestNetParams):
     SUBSIDY_HALVING_INTERVAL = 150
     PROOF_OF_WORK_LIMIT = 2**256-1 >> 1
 
+class CoreSimNetParams(CoreTestNetParams):
+    NAME = 'simnet'
+    GENESIS_BLOCK = CBlock.deserialize(x('0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f20020000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000'))
+    SUBSIDY_HALVING_INTERVAL = 210000
+    PROOF_OF_WORK_LIMIT = 2**256-1 >> 1
+
+
 """Master global setting for what core chain params we're using"""
 coreparams = CoreMainParams()
 
@@ -774,6 +781,8 @@ def _SelectCoreParams(name):
         coreparams = CoreTestNetParams()
     elif name == 'regtest':
         coreparams = CoreRegTestParams()
+    elif name == 'simnet':
+        coreparams = CoreSimNetParams()
     else:
         raise ValueError('Unknown chain %r' % name)
 


### PR DESCRIPTION
Adding support for simnet.

Parameters referenced from [btcd](https://github.com/btcsuite/btcd/blob/master/chaincfg/params.go).

Only parameter here I couldn't find was for `MESSAGE_START`. Let me know if there is a standard resource out there to figure this one out. 