### PR TITLE
Fix incorrect use of NotImplementedError

### DIFF
--- a/bitcoin/wallet.py
+++ b/bitcoin/wallet.py
@@ -308,7 +308,7 @@ class P2WSHBitcoinAddress(CBech32BitcoinAddress):
         return script.CScript([0, self])
 
     def to_redeemScript(self):
-        return NotImplementedError("not enough data in p2wsh address to reconstruct redeem script")
+        raise NotImplementedError("Not enough data in p2wsh address to reconstruct redeem script")
 
 
 class P2WPKHBitcoinAddress(CBech32BitcoinAddress):


### PR DESCRIPTION
This was incorrect. I guess the author copy-pasted the code from somewhere or was thinking of `return NotImplemented` (which wouldn't even make sense here).