### PR TITLE
Escape newlines: fix sphinx warnings

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -374,9 +374,9 @@ class Proxy(BaseProxy):
 
         Returns dict:
 
-        {'tx':        Resulting tx,
-         'fee':       Fee the resulting transaction pays,
-         'changepos': Position of added change output, or -1,
+        {'tx':        Resulting tx,\
+         'fee':       Fee the resulting transaction pays,\
+         'changepos': Position of added change output, or -1,\
         }
         """
         hextx = hexlify(tx.serialize())


### PR DESCRIPTION
Fix for the unexpected unindent error Sphinx raises when generating docs. Adding the escapes will fix that warning. 

We should move to explicitly specifying params in docstrings.