### PR TITLE
Fix file location of .cookie when on testnet.

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -171,7 +171,10 @@ class BaseProxy(object):
 
             cookie_dir = conf.get('datadir', os.path.dirname(btc_conf_file))
             if bitcoin.params.NAME != "mainnet":
-                cookie_dir = os.path.join(cookie_dir, bitcoin.params.NAME)
+                if bitcoin.params.NAME == 'testnet':
+                    cookie_dir = os.path.join(cookie_dir, 'testnet3')
+                elif bitcoin.params.NAME == 'regtest'
+                    cookie_dir = os.path.join(cookie_dir, bitcoin.params.NAME)
             cookie_file = os.path.join(cookie_dir, ".cookie")
             try:
                 with open(cookie_file, 'r') as fd:


### PR DESCRIPTION
The data directory for the cookie file used for authentication should be `~/.bitcoin/testnet3/` when connecting to bitcoin core through RPC on testnet.