### PR TITLE
Fix file location of .cookie when on testnet

### DIFF
--- a/bitcoin/rpc.py
+++ b/bitcoin/rpc.py
@@ -170,7 +170,9 @@ class BaseProxy(object):
                 ('http', conf['rpchost'], conf['rpcport']))
 
             cookie_dir = conf.get('datadir', os.path.dirname(btc_conf_file))
-            if bitcoin.params.NAME != "mainnet":
+            if bitcoin.params.NAME == 'testnet':
+                cookie_dir = os.path.join(cookie_dir, 'testnet3')
+            elif bitcoin.params.NAME == 'regtest':
                 cookie_dir = os.path.join(cookie_dir, bitcoin.params.NAME)
             cookie_file = os.path.join(cookie_dir, ".cookie")
             try:


### PR DESCRIPTION
The data directory for the cookie file used for authentication should be `~/.bitcoin/testnet3` when connecting to bitcoin core testnet through RPC.