### PR TITLE
Check that secrets are exactly 32 bytes

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -264,6 +264,8 @@ class CECKey:
         self.k = None
 
     def set_secretbytes(self, secret):
+        if(len(secret) != 32):
+            raise ValueError("Secret bytes must be exactly 32 bytes")
         priv_key = _ssl.BN_bin2bn(secret, 32, None)
         group = _ssl.EC_KEY_get0_group(self.k)
         pub_key = _ssl.EC_POINT_new(group)


### PR DESCRIPTION
Fixes #239.

I agree with @dgpv, any padding should be performed by the user and we shouldn't be doing any unexpected transformations on the user's secret key material. So we just raise an exception if anything other than exactly 32 bytes are passed.