### PR TITLE
docs: fix simple typo, probabably -> probably

### DIFF
--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -11,7 +11,7 @@
 
 """Serialization routines
 
-You probabably don't need to use these directly.
+You probably don't need to use these directly.
 """
 
 from __future__ import absolute_import, division, print_function, unicode_literals


### PR DESCRIPTION
There is a small typo in bitcoin/core/serialize.py.

Should read `probably` rather than `probabably`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md