### PR TITLE
Pass strSubVer.encode() to serializer

### DIFF
--- a/bitcoin/messages.py
+++ b/bitcoin/messages.py
@@ -160,7 +160,7 @@ class msg_version(MsgSerializable):
         self.addrTo.stream_serialize(f, True)
         self.addrFrom.stream_serialize(f, True)
         f.write(struct.pack(b"<Q", self.nNonce))
-        VarStringSerializer.stream_serialize(self.strSubVer, f)
+        VarStringSerializer.stream_serialize(self.strSubVer.encode(), f)
         f.write(struct.pack(b"<i", self.nStartingHeight))
         f.write(struct.pack(b"<B", self.fRelay))
 


### PR DESCRIPTION
The serializer expects bytes, but strSubVer is a string. So it needs to be encoded first.