### PR TITLE
Update key.py

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -25,7 +25,7 @@ import bitcoin.signature
 import bitcoin.core.script
 
 _ssl = ctypes.cdll.LoadLibrary(
-    ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl') or 'libeay32'
+    ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl') or ctypes.util.find_library('libeay32')
 )
 
 _libsecp256k1_path = ctypes.util.find_library('secp256k1')


### PR DESCRIPTION
To resolve the error `FileNotFoundError: Could not find module 'libeay32' (or one of its dependencies). Try using the full path with constructor syntax.` occurring on Windows, as mentioned in #262. This fix was just a guess that appears to have worked for me in my use case; perhaps someone else can chip in on whether it's actually a general solution to the aforementioned issue?