### PR TITLE
core: support openssl 3

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -26,6 +26,7 @@ import bitcoin.core.script
 
 _ssl = ctypes.cdll.LoadLibrary(
     ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl') or ctypes.util.find_library('libeay32')
+    or ctypes.cdll.LoadLibrary("libcrypto")
 )
 
 _libsecp256k1_path = ctypes.util.find_library('secp256k1')


### PR DESCRIPTION
In modern version of openssl (iirc from 1.1) the
library `libeay32` is removed in favour of libcrypto.

See for more info https://github.com/openssl/openssl/issues/10332

This commit adds the possibility to include libcrypto too

Fixing the following error on a nix shell

```
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/_pytest/config/__init__.py:325: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown. Plugin: helpconfig, Hook: pytest_cmdline_parse
ConftestImportFailure: OSError: libeay32: cannot open shared object file: No such file or directory (from /home/vincent/gittea/work/lampo.rs/tests/lnprototest/tests/conftest.py) For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
  config = pluginmanager.hook.pytest_cmdline_parse(
ImportError while loading conftest '/home/vincent/gittea/work/lampo.rs/tests/lnprototest/tests/conftest.py'.
tests/conftest.py:3: in <module>
    import lnprototest
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/lnprototest/__init__.py:15: in <module>
    from .event import (
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/lnprototest/event.py:16: in <module>
    from .namespace import namespace
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/lnprototest/namespace.py:6: in <module>
    from .signature import SigType
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/lnprototest/signature.py:5: in <module>
    from .utils import check_hex, privkey_expand
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/lnprototest/utils/__init__.py:18: in <module>
    from .bitcoin_utils import (
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/lnprototest/utils/bitcoin_utils.py:14: in <module>
    from bitcoin.wallet import CBitcoinSecret
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/bitcoin/wallet.py:23: in <module>
    import bitcoin.core.key
/home/vincent/.cache/pypoetry/virtualenvs/lampo-lnprototest-IQvPSNpc-py3.11/lib/python3.11/site-packages/bitcoin/core/key.py:27: in <module>
    _ssl = ctypes.cdll.LoadLibrary(
/nix/store/sxr2igfkwhxbagri49b8krmcqz168sim-python3-3.11.8/lib/python3.11/ctypes/__init__.py:454: in LoadLibrary
    return self._dlltype(name)
/nix/store/sxr2igfkwhxbagri49b8krmcqz168sim-python3-3.11.8/lib/python3.11/ctypes/__init__.py:376: in __init__
    self._handle = _dlopen(self._name, mode)
E   OSError: libeay32: cannot open shared object file: No such file or directory
make[1]: *** [Makefile:11: check] Error 4
```