### PR TITLE
core: Fix a bug with loading libcrypto

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -26,7 +26,7 @@ import bitcoin.core.script
 
 _ssl = ctypes.cdll.LoadLibrary(
     ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl') or ctypes.util.find_library('libeay32')
-    or ctypes.cdll.LoadLibrary("libcrypto")
+    or ctypes.util.find_library('libcrypto')
 )
 
 _libsecp256k1_path = ctypes.util.find_library('secp256k1')


### PR DESCRIPTION
Looks like the fix in https://github.com/petertodd/python-bitcoinlib/pull/301 was not working.

I got the following error while trying to run `from bitcoin.rpc import Proxy` on my machine

```
File ~\OneDrive\Documents\GitHub\python-bitcoinlib\bitcoin\rpc.py:38
     36 from bitcoin.core import COIN, x, lx, b2lx, CBlock, CBlockHeader, CTransaction, COutPoint, CTxOut
     37 from bitcoin.core.script import CScript
---> 38 from bitcoin.wallet import CBitcoinAddress, CBitcoinSecret
     40 DEFAULT_USER_AGENT = "AuthServiceProxy/0.1"
     42 DEFAULT_HTTP_TIMEOUT = 30

File ~\OneDrive\Documents\GitHub\python-bitcoinlib\bitcoin\wallet.py:23
     21 import bitcoin.bech32
     22 import bitcoin.core
---> 23 import bitcoin.core.key
     24 import bitcoin.core.script as script
     27 class CBitcoinAddress(object):

File ~\OneDrive\Documents\GitHub\python-bitcoinlib\bitcoin\core\key.py:27
     23 import bitcoin.signature
     25 import bitcoin.core.script
---> 27 _ssl = ctypes.cdll.LoadLibrary(
     28     ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl') or ctypes.util.find_library('libeay32')
     29     or ctypes.cdll.LoadLibrary("libcrypto")
     30 )
     32 _libsecp256k1_path = ctypes.util.find_library('secp256k1')
     33 _libsecp256k1_enable_signing = False

File ~\.pyenv\pyenv-win\versions\3.12.7\Lib\ctypes\__init__.py:460, in LibraryLoader.LoadLibrary(self, name)
    459 def LoadLibrary(self, name):
--> 460     return self._dlltype(name)

File ~\.pyenv\pyenv-win\versions\3.12.7\Lib\ctypes\__init__.py:348, in CDLL.__init__(self, name, mode, handle, use_errno, use_last_error, winmode)
    343 def __init__(self, name, mode=DEFAULT_MODE, handle=None,
    344              use_errno=False,
    345              use_last_error=False,
    346              winmode=None):
    347     if name:
--> 348         name = _os.fspath(name)
    349     self._name = name
    350     flags = self._func_flags_

TypeError: expected str, bytes or os.PathLike object, not CDLL