### PR TITLE
Update serialize.py (Docstring Typo:)

### DIFF
--- a/bitcoin/core/serialize.py
+++ b/bitcoin/core/serialize.py
@@ -26,7 +26,7 @@ MAX_SIZE = 0x02000000
 
 
 def Hash(msg):
-    """SHA256^2)(msg) -> bytes"""
+    """SHA256^2(msg) -> bytes"""
     return hashlib.sha256(hashlib.sha256(msg).digest()).digest()
 
 def Hash160(msg):


### PR DESCRIPTION
The closing parenthesis in the docstring should be removed.