### PR TITLE
script: add OP_TRUE and OP_FALSE aliases to OPCODES_BY_NAME

### DIFF
--- a/bitcoin/core/script.py
+++ b/bitcoin/core/script.py
@@ -365,12 +365,14 @@ OPCODE_NAMES.update({
 
 OPCODES_BY_NAME = {
     'OP_0': OP_0,
+    'OP_FALSE': OP_0,
     'OP_PUSHDATA1': OP_PUSHDATA1,
     'OP_PUSHDATA2': OP_PUSHDATA2,
     'OP_PUSHDATA4': OP_PUSHDATA4,
     'OP_1NEGATE': OP_1NEGATE,
     'OP_RESERVED': OP_RESERVED,
     'OP_1': OP_1,
+    'OP_TRUE': OP_1,
     'OP_2': OP_2,
     'OP_3': OP_3,
     'OP_4': OP_4,

--- a/bitcoin/tests/test_script.py
+++ b/bitcoin/tests/test_script.py
@@ -44,6 +44,10 @@ class Test_CScriptOp(unittest.TestCase):
         for i in range(0x0, 0x100):
             self.assertTrue(CScriptOp(i) is CScriptOp(i))
 
+    def test_boolean_aliases_are_available_by_name(self):
+        self.assertIs(OPCODES_BY_NAME['OP_FALSE'], OP_0)
+        self.assertIs(OPCODES_BY_NAME['OP_TRUE'], OP_1)
+
     def test_encode_decode_op_n(self):
         def t(n, op):
             actual = CScriptOp.encode_op_n(n)


### PR DESCRIPTION
## Summary

`OP_TRUE` and `OP_FALSE` already exist as aliases for `OP_1` and `OP_0`, but they are absent from `OPCODES_BY_NAME`. Code that parses textual script tokens therefore cannot resolve these standard boolean names.

Add both aliases to the lookup table, as requested by a repository collaborator in issue #225, and cover their exact singleton mappings.

Fixes #225.

## Verification

- `python -m unittest bitcoin.tests.test_script -v` — 19 passed.
- Touched files compile successfully and the diff whitespace check passes.