### PR TITLE
core: raise clear error when OpenSSL library is not found

### DIFF
--- a/bitcoin/core/key.py
+++ b/bitcoin/core/key.py
@@ -23,11 +23,16 @@ import bitcoin
 import bitcoin.signature
 
 import bitcoin.core.script
-
-_ssl = ctypes.cdll.LoadLibrary(
-    ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl') or ctypes.util.find_library('libeay32')
-    or ctypes.util.find_library('libcrypto')
+_ssl_library = (
+    ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl')
+    or ctypes.util.find_library('libeay32') or ctypes.util.find_library('libcrypto')
 )
+if _ssl_library is None:
+    raise EnvironmentError(
+        "OpenSSL library not found. "
+        "Install OpenSSL and ensure it is on your PATH or system library path."
+    )
+_ssl = ctypes.cdll.LoadLibrary(_ssl_library)
 
 _libsecp256k1_path = ctypes.util.find_library('secp256k1')
 _libsecp256k1_enable_signing = False

--- a/bitcoin/tests/test_key.py
+++ b/bitcoin/tests/test_key.py
@@ -10,6 +10,8 @@
 # LICENSE file.
 
 
+import subprocess
+import sys
 import unittest
 
 from bitcoin.core.key import *
@@ -38,3 +40,29 @@ class Test_CPubKey(unittest.TestCase):
 
         T('0478d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c71a1518063243acd4dfe96b66e3f2ec8013c8e072cd09b3834a19f81f659cc3455',
           True, True, False)
+
+
+class Test_OpenSSLLoading(unittest.TestCase):
+    def test_missing_library_raises_clear_error(self):
+        code = """
+import ctypes.util
+ctypes.util.find_library = lambda name: None
+
+try:
+    import bitcoin.core.key
+except EnvironmentError as exc:
+    assert str(exc) == (
+        "OpenSSL library not found. Install OpenSSL and ensure it is on your "
+        "PATH or system library path."
+    )
+else:
+    raise AssertionError("bitcoin.core.key imported without OpenSSL")
+"""
+
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)


### PR DESCRIPTION
## Summary

On Windows, every `ctypes.util.find_library()` candidate can return `None`. Passing that value directly to `ctypes.cdll.LoadLibrary()` raises a confusing `TypeError`.

Check the resolved path first and raise an actionable `EnvironmentError` explaining that OpenSSL must be installed and discoverable.

Fixes #316.

## Verification

- Added a subprocess regression that mocks every library lookup to `None` and asserts the exact public error.
- `python -m unittest bitcoin.tests.test_key -v` — 2 passed.
- Touched files compile successfully and the diff whitespace check passes.